### PR TITLE
Implement time travel query support

### DIFF
--- a/src/lakehouse/query.py
+++ b/src/lakehouse/query.py
@@ -77,6 +77,36 @@ class QueryEngine:
         result = conn.execute(sql)
         return result.fetchdf()
 
+    def execute_as_of(
+        self,
+        sql: str,
+        table_name: str,
+        as_of: str,
+        max_rows: int = 1000,
+    ) -> pd.DataFrame:
+        """Execute SQL query against a historical snapshot of a table.
+
+        Loads the table at the given snapshot/timestamp and registers it
+        temporarily for the query, then restores the current version.
+        """
+        from .catalog import get_catalog, scan_as_of
+
+        catalog = get_catalog()
+        arrow_table = scan_as_of(catalog, table_name, as_of)
+
+        # Use a temporary connection to avoid polluting the main one
+        conn = duckdb.connect(":memory:")
+        short_name = table_name.split(".")[-1] if "." in table_name else table_name
+        conn.register(short_name, arrow_table)
+
+        sql_upper = sql.strip().upper()
+        if sql_upper.startswith("SELECT") and "LIMIT" not in sql_upper:
+            sql = f"{sql.rstrip(';')} LIMIT {max_rows}"
+
+        result = conn.execute(sql).fetchdf()
+        conn.close()
+        return result
+
     def execute_raw(self, sql: str) -> duckdb.DuckDBPyRelation:
         """Execute SQL and return raw DuckDB relation."""
         conn = self._get_connection()


### PR DESCRIPTION
## Summary
- Adds `get_snapshots` and `scan_as_of` to catalog for snapshot listing and historical scans
- Adds `execute_as_of` to `QueryEngine` for time travel queries via DuckDB
- New MCP `list_snapshots` tool to discover available snapshots
- Extends MCP `query` tool with `as_of` and `table_name` params for time travel
- CLI: `lakehouse query SQL --as-of TIMESTAMP --table-name TABLE`
- CLI: `lakehouse snapshots TABLE_NAME`
- Supports both ISO timestamps (`2025-12-01T00:00:00`) and snapshot IDs

Closes #7

## Test plan
- [ ] `lakehouse snapshots expenses` — lists all snapshots with IDs and timestamps
- [ ] `lakehouse query "SELECT * FROM expenses" --as-of "2025-12-01T00:00:00" --table-name expenses` — queries historical data
- [ ] `lakehouse query "SELECT * FROM expenses" --as-of SNAPSHOT_ID --table-name expenses` — queries by snapshot ID
- [ ] Error when `--as-of` used without `--table-name`
- [ ] Error on invalid timestamp or non-existent snapshot ID
- [ ] MCP `list_snapshots` and `query` with `as_of` work via Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)