### PR TITLE
Add comprehensive tests for all write operations (#10)

### DIFF
--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,148 @@
+"""Tests for batch/transaction operations."""
+
+import pytest
+
+from lakehouse.catalog import insert_rows, execute_batch
+
+
+class TestExecuteBatch:
+    """Test execute_batch function."""
+
+    def test_batch_multiple_inserts(self, test_catalog, query_engine):
+        """Test batch with multiple insert operations."""
+        ops = [
+            {"action": "insert", "table_name": "expenses", "rows": [
+                {"id": 7000, "category": "batch1", "amount": 10.0, "currency": "USD"},
+            ]},
+            {"action": "insert", "table_name": "expenses", "rows": [
+                {"id": 7001, "category": "batch2", "amount": 20.0, "currency": "EUR"},
+            ]},
+        ]
+
+        results = execute_batch(test_catalog, ops)
+        assert len(results) == 2
+        assert all(r["status"] == "ok" for r in results)
+        assert results[0]["rows_affected"] == 1
+        assert results[1]["rows_affected"] == 1
+
+        query_engine.refresh()
+        rows = query_engine.execute("SELECT * FROM expenses WHERE id IN (7000, 7001) ORDER BY id")
+        assert len(rows) == 2
+
+    def test_batch_insert_update_delete(self, test_catalog, query_engine):
+        """Test batch with mixed operations."""
+        # Setup
+        insert_rows(test_catalog, "expenses", [
+            {"id": 7010, "category": "to_update", "amount": 50.0, "currency": "USD"},
+            {"id": 7011, "category": "to_delete", "amount": 30.0, "currency": "USD"},
+        ])
+
+        ops = [
+            {"action": "insert", "table_name": "expenses", "rows": [
+                {"id": 7012, "category": "new", "amount": 15.0, "currency": "GBP"},
+            ]},
+            {"action": "update", "table_name": "expenses", "filter": "id = 7010", "updates": {"amount": 99.0}},
+            {"action": "delete", "table_name": "expenses", "filter": "id = 7011"},
+        ]
+
+        results = execute_batch(test_catalog, ops)
+        assert len(results) == 3
+        assert all(r["status"] == "ok" for r in results)
+
+        query_engine.refresh()
+        # Verify insert
+        new_row = query_engine.execute("SELECT * FROM expenses WHERE id = 7012")
+        assert len(new_row) == 1
+
+        # Verify update
+        updated = query_engine.execute("SELECT * FROM expenses WHERE id = 7010")
+        assert updated.iloc[0]["amount"] == 99.0
+
+        # Verify delete
+        deleted = query_engine.execute("SELECT * FROM expenses WHERE id = 7011")
+        assert len(deleted) == 0
+
+    def test_batch_stops_on_first_error(self, test_catalog):
+        """Test that batch stops on first failure and skips remaining."""
+        ops = [
+            {"action": "insert", "table_name": "expenses", "rows": [
+                {"id": 7020, "category": "ok", "amount": 10.0, "currency": "USD"},
+            ]},
+            {"action": "insert", "table_name": "nonexistent_table", "rows": [
+                {"id": 1, "field": "bad"},
+            ]},
+            {"action": "insert", "table_name": "expenses", "rows": [
+                {"id": 7021, "category": "skipped", "amount": 20.0, "currency": "USD"},
+            ]},
+        ]
+
+        results = execute_batch(test_catalog, ops)
+        assert len(results) == 3
+        assert results[0]["status"] == "ok"
+        assert results[1]["status"] == "error"
+        assert results[2]["status"] == "skipped"
+
+    def test_batch_missing_action(self, test_catalog):
+        """Test batch with missing action field."""
+        ops = [{"table_name": "expenses", "rows": [{"id": 1}]}]
+        results = execute_batch(test_catalog, ops)
+        assert results[0]["status"] == "error"
+        assert "action" in results[0]["message"].lower()
+
+    def test_batch_missing_table_name(self, test_catalog):
+        """Test batch with missing table_name."""
+        ops = [{"action": "insert", "rows": [{"id": 1}]}]
+        results = execute_batch(test_catalog, ops)
+        assert results[0]["status"] == "error"
+        assert "table_name" in results[0]["message"].lower()
+
+    def test_batch_missing_rows_for_insert(self, test_catalog):
+        """Test batch insert without rows."""
+        ops = [{"action": "insert", "table_name": "expenses"}]
+        results = execute_batch(test_catalog, ops)
+        assert results[0]["status"] == "error"
+        assert "rows" in results[0]["message"].lower()
+
+    def test_batch_missing_filter_for_update(self, test_catalog):
+        """Test batch update without filter."""
+        ops = [{"action": "update", "table_name": "expenses", "updates": {"amount": 10}}]
+        results = execute_batch(test_catalog, ops)
+        assert results[0]["status"] == "error"
+
+    def test_batch_missing_filter_for_delete(self, test_catalog):
+        """Test batch delete without filter."""
+        ops = [{"action": "delete", "table_name": "expenses"}]
+        results = execute_batch(test_catalog, ops)
+        assert results[0]["status"] == "error"
+
+    def test_batch_unknown_action(self, test_catalog):
+        """Test batch with unknown action."""
+        ops = [{"action": "truncate", "table_name": "expenses"}]
+        results = execute_batch(test_catalog, ops)
+        assert results[0]["status"] == "error"
+        assert "Unknown action" in results[0]["message"]
+
+    def test_batch_empty_raises_error(self, test_catalog):
+        """Test batch with empty operations list."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            execute_batch(test_catalog, [])
+
+    def test_batch_cross_table(self, test_catalog, query_engine):
+        """Test batch across multiple tables."""
+        ops = [
+            {"action": "insert", "table_name": "expenses", "rows": [
+                {"id": 7050, "category": "cross", "amount": 10.0, "currency": "USD"},
+            ]},
+            {"action": "insert", "table_name": "health", "rows": [
+                {"id": 7050, "metric_type": "steps", "value": 5000.0, "unit": "count", "source": "test"},
+            ]},
+        ]
+
+        results = execute_batch(test_catalog, ops)
+        assert all(r["status"] == "ok" for r in results)
+
+        query_engine.refresh()
+        exp = query_engine.execute("SELECT * FROM expenses WHERE id = 7050")
+        assert len(exp) == 1
+        health = query_engine.execute("SELECT * FROM health WHERE id = 7050")
+        assert len(health) == 1

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,114 @@
+"""Tests for DELETE operations."""
+
+import pytest
+
+from lakehouse.catalog import insert_rows, delete_rows
+
+
+class TestDeleteRows:
+    """Test delete_rows function."""
+
+    def test_delete_single_row_by_id(self, test_catalog, query_engine):
+        """Test deleting a single row by ID."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 2000, "category": "food", "amount": 50.0, "currency": "USD"},
+            {"id": 2001, "category": "transport", "amount": 20.0, "currency": "USD"},
+        ])
+
+        count = delete_rows(test_catalog, "expenses", "id = 2000")
+        assert count == 1
+
+        query_engine.refresh()
+        result = query_engine.execute("SELECT * FROM expenses WHERE id IN (2000, 2001)")
+        assert len(result) == 1
+        assert result.iloc[0]["id"] == 2001
+
+    def test_delete_multiple_rows(self, test_catalog, query_engine):
+        """Test deleting multiple rows matching a filter."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 2010, "category": "food", "amount": 25.0, "currency": "USD"},
+            {"id": 2011, "category": "food", "amount": 30.0, "currency": "USD"},
+            {"id": 2012, "category": "transport", "amount": 15.0, "currency": "USD"},
+        ])
+
+        count = delete_rows(test_catalog, "expenses", "category = 'food'")
+        assert count == 2
+
+        query_engine.refresh()
+        result = query_engine.execute("SELECT * FROM expenses WHERE id IN (2010, 2011, 2012)")
+        assert len(result) == 1
+        assert result.iloc[0]["id"] == 2012
+
+    def test_delete_no_matching_rows(self, test_catalog, query_engine):
+        """Test deleting when no rows match."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 2020, "category": "test", "amount": 10.0, "currency": "USD"},
+        ])
+
+        count = delete_rows(test_catalog, "expenses", "category = 'nonexistent'")
+        assert count == 0
+
+        query_engine.refresh()
+        result = query_engine.execute("SELECT * FROM expenses WHERE id = 2020")
+        assert len(result) == 1
+
+    def test_delete_with_numeric_filter(self, test_catalog, query_engine):
+        """Test deleting with numeric comparison."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 2030, "category": "a", "amount": 100.0, "currency": "USD"},
+            {"id": 2031, "category": "b", "amount": 50.0, "currency": "USD"},
+            {"id": 2032, "category": "c", "amount": 200.0, "currency": "USD"},
+        ])
+
+        count = delete_rows(test_catalog, "expenses", "amount > 75")
+        assert count == 2
+
+        query_engine.refresh()
+        result = query_engine.execute("SELECT * FROM expenses WHERE id IN (2030, 2031, 2032)")
+        assert len(result) == 1
+        assert result.iloc[0]["amount"] == 50.0
+
+    def test_delete_with_and_filter(self, test_catalog, query_engine):
+        """Test deleting with compound filter."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 2040, "category": "food", "amount": 100.0, "currency": "USD"},
+            {"id": 2041, "category": "food", "amount": 30.0, "currency": "USD"},
+        ])
+
+        count = delete_rows(test_catalog, "expenses", "category = 'food' AND amount > 50")
+        assert count == 1
+
+        query_engine.refresh()
+        result = query_engine.execute("SELECT * FROM expenses WHERE id IN (2040, 2041)")
+        assert len(result) == 1
+        assert result.iloc[0]["id"] == 2041
+
+    def test_delete_empty_filter_raises_error(self, test_catalog):
+        """Test that empty filter raises an error."""
+        with pytest.raises(ValueError, match="Filter expression is required"):
+            delete_rows(test_catalog, "expenses", "")
+
+    def test_delete_nonexistent_table_raises_error(self, test_catalog):
+        """Test that deleting from non-existent table raises error."""
+        with pytest.raises(ValueError, match="not found"):
+            delete_rows(test_catalog, "nonexistent_table", "id = 1")
+
+    def test_delete_from_empty_table(self, test_catalog):
+        """Test deleting from empty table returns 0."""
+        count = delete_rows(test_catalog, "expenses", "id = 9999")
+        assert count == 0
+
+    def test_delete_preserves_other_rows(self, test_catalog, query_engine):
+        """Test that delete doesn't affect non-matching rows."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 2050, "category": "target", "amount": 10.0, "currency": "USD"},
+            {"id": 2051, "category": "keep", "amount": 20.0, "currency": "EUR"},
+        ])
+
+        delete_rows(test_catalog, "expenses", "id = 2050")
+
+        query_engine.refresh()
+        result = query_engine.execute("SELECT * FROM expenses WHERE id = 2051")
+        assert len(result) == 1
+        assert result.iloc[0]["amount"] == 20.0
+        assert result.iloc[0]["currency"] == "EUR"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,88 @@
+"""Tests for schema evolution operations."""
+
+import pytest
+
+from lakehouse.catalog import alter_table, get_table_schema, insert_rows
+
+
+class TestSchemaEvolution:
+    """Test alter_table function."""
+
+    def test_add_column(self, test_catalog):
+        """Test adding a column to a table."""
+        result = alter_table(test_catalog, "expenses", "add_column", "tags", column_type="string")
+        assert "Added column" in result
+        assert "tags" in result
+
+        schema = get_table_schema(test_catalog, "expenses")
+        field_names = [f["name"] for f in schema["fields"]]
+        assert "tags" in field_names
+
+    def test_drop_column(self, test_catalog):
+        """Test dropping a column from a table."""
+        result = alter_table(test_catalog, "expenses", "drop_column", "currency")
+        assert "Dropped column" in result
+
+        schema = get_table_schema(test_catalog, "expenses")
+        field_names = [f["name"] for f in schema["fields"]]
+        assert "currency" not in field_names
+
+    def test_rename_column(self, test_catalog):
+        """Test renaming a column."""
+        result = alter_table(test_catalog, "expenses", "rename_column", "description", new_name="desc")
+        assert "Renamed column" in result
+
+        schema = get_table_schema(test_catalog, "expenses")
+        field_names = [f["name"] for f in schema["fields"]]
+        assert "desc" in field_names
+        assert "description" not in field_names
+
+    def test_add_column_all_types(self, test_catalog):
+        """Test adding columns of all supported types."""
+        for col_type in ["string", "long", "double", "date", "timestamp"]:
+            col_name = f"test_{col_type}"
+            result = alter_table(test_catalog, "expenses", "add_column", col_name, column_type=col_type)
+            assert "Added column" in result
+
+    def test_add_column_missing_type_raises_error(self, test_catalog):
+        """Test that add_column without type raises error."""
+        with pytest.raises(ValueError, match="column_type is required"):
+            alter_table(test_catalog, "expenses", "add_column", "new_col")
+
+    def test_add_column_invalid_type_raises_error(self, test_catalog):
+        """Test that add_column with invalid type raises error."""
+        with pytest.raises(ValueError, match="Unsupported column type"):
+            alter_table(test_catalog, "expenses", "add_column", "new_col", column_type="invalid_type")
+
+    def test_rename_column_missing_new_name_raises_error(self, test_catalog):
+        """Test that rename without new_name raises error."""
+        with pytest.raises(ValueError, match="new_name is required"):
+            alter_table(test_catalog, "expenses", "rename_column", "description")
+
+    def test_unknown_operation_raises_error(self, test_catalog):
+        """Test that unknown operation raises error."""
+        with pytest.raises(ValueError, match="Unknown operation"):
+            alter_table(test_catalog, "expenses", "widen_column", "id")
+
+    def test_nonexistent_table_raises_error(self, test_catalog):
+        """Test that altering non-existent table raises error."""
+        with pytest.raises(ValueError, match="not found"):
+            alter_table(test_catalog, "nonexistent", "add_column", "col", column_type="string")
+
+    def test_add_column_then_insert(self, test_catalog, query_engine):
+        """Test that new column can be populated after adding."""
+        alter_table(test_catalog, "expenses", "add_column", "priority", column_type="string")
+
+        insert_rows(test_catalog, "expenses", [
+            {"id": 5000, "category": "test", "amount": 10.0, "priority": "high"},
+        ])
+
+        query_engine.refresh()
+        result = query_engine.execute("SELECT * FROM expenses WHERE id = 5000")
+        assert len(result) == 1
+        assert result.iloc[0]["priority"] == "high"
+
+    def test_add_column_with_namespace_prefix(self, test_catalog):
+        """Test adding column with fully qualified table name."""
+        result = alter_table(test_catalog, "default.expenses", "add_column", "notes", column_type="string")
+        assert "Added column" in result

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,0 +1,162 @@
+"""Tests for snapshot management (rollback, expire)."""
+
+import datetime
+import pytest
+
+from lakehouse.catalog import (
+    insert_rows,
+    update_rows,
+    get_snapshots,
+    rollback_table,
+    expire_snapshots,
+)
+
+
+class TestRollback:
+    """Test rollback_table function."""
+
+    def test_rollback_to_snapshot_id(self, test_catalog, query_engine):
+        """Test rolling back to a specific snapshot."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 6000, "category": "original", "amount": 50.0, "currency": "USD"},
+        ])
+        snapshots = get_snapshots(test_catalog, "expenses")
+        first_snap = snapshots[-1]["snapshot_id"]
+
+        # Make a change
+        insert_rows(test_catalog, "expenses", [
+            {"id": 6001, "category": "added_later", "amount": 100.0, "currency": "USD"},
+        ])
+
+        # Rollback
+        result = rollback_table(test_catalog, "expenses", snapshot_id=first_snap)
+        assert "Rolled back" in result["message"]
+
+        # Verify only original data remains
+        query_engine.refresh()
+        rows = query_engine.execute("SELECT * FROM expenses WHERE id IN (6000, 6001)")
+        ids = rows["id"].tolist()
+        assert 6000 in ids
+        assert 6001 not in ids
+
+    def test_rollback_to_timestamp(self, test_catalog, query_engine):
+        """Test rolling back to a timestamp."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 6010, "category": "original", "amount": 10.0, "currency": "USD"},
+        ])
+
+        # Use a future timestamp that includes this snapshot
+        future = (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=5)).isoformat()
+
+        # Add more data
+        insert_rows(test_catalog, "expenses", [
+            {"id": 6011, "category": "later", "amount": 20.0, "currency": "USD"},
+        ])
+
+        # Get the first snapshot timestamp
+        snapshots = get_snapshots(test_catalog, "expenses")
+        first_ts = snapshots[0]["timestamp"]
+
+        result = rollback_table(test_catalog, "expenses", timestamp=first_ts)
+        assert "Rolled back" in result["message"]
+
+    def test_rollback_already_at_snapshot(self, test_catalog):
+        """Test rollback when already at target snapshot."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 6020, "category": "test", "amount": 10.0, "currency": "USD"},
+        ])
+        snapshots = get_snapshots(test_catalog, "expenses")
+        current = snapshots[-1]["snapshot_id"]
+
+        result = rollback_table(test_catalog, "expenses", snapshot_id=current)
+        assert "no rollback needed" in result["message"].lower()
+
+    def test_rollback_no_params_raises_error(self, test_catalog):
+        """Test rollback with neither snapshot_id nor timestamp."""
+        with pytest.raises(ValueError, match="Either snapshot_id or timestamp"):
+            rollback_table(test_catalog, "expenses")
+
+    def test_rollback_invalid_snapshot_raises_error(self, test_catalog):
+        """Test rollback to non-existent snapshot."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 6030, "category": "test", "amount": 10.0, "currency": "USD"},
+        ])
+        with pytest.raises(ValueError, match="not found"):
+            rollback_table(test_catalog, "expenses", snapshot_id=999999999999)
+
+    def test_rollback_nonexistent_table_raises_error(self, test_catalog):
+        """Test rollback on non-existent table."""
+        with pytest.raises(ValueError, match="not found"):
+            rollback_table(test_catalog, "nonexistent", snapshot_id=1)
+
+    def test_rollback_empty_table_raises_error(self, test_catalog):
+        """Test rollback on table with no snapshots."""
+        with pytest.raises(ValueError, match="no snapshots"):
+            rollback_table(test_catalog, "expenses", snapshot_id=1)
+
+
+class TestExpireSnapshots:
+    """Test expire_snapshots function."""
+
+    def test_expire_no_params_raises_error(self, test_catalog):
+        """Test expire without older_than or retain_last raises error."""
+        with pytest.raises(ValueError, match="Either older_than or retain_last"):
+            expire_snapshots(test_catalog, "expenses")
+
+    def test_expire_nonexistent_table_raises_error(self, test_catalog):
+        """Test expire on non-existent table raises error."""
+        with pytest.raises(ValueError, match="not found"):
+            expire_snapshots(test_catalog, "nonexistent", older_than="30d")
+
+    def test_expire_retain_last(self, test_catalog):
+        """Test expiring snapshots with retain_last."""
+        # Create multiple snapshots
+        for i in range(4):
+            insert_rows(test_catalog, "expenses", [
+                {"id": 6100 + i, "category": f"batch_{i}", "amount": float(i), "currency": "USD"},
+            ])
+
+        before = get_snapshots(test_catalog, "expenses")
+        assert len(before) >= 4
+
+        result = expire_snapshots(test_catalog, "expenses", retain_last=2)
+        assert "remaining" in result
+        assert result["remaining"] >= 2
+
+    def test_expire_older_than_duration(self, tmp_path):
+        """Test expiring with duration string (recent data not expired)."""
+        from pyiceberg.catalog.sql import SqlCatalog
+        catalog = SqlCatalog(
+            "expire_dur_test",
+            **{"uri": f"sqlite:///{tmp_path / 'c.db'}", "warehouse": f"file://{tmp_path / 'w'}"},
+        )
+        (tmp_path / "w").mkdir()
+        catalog.create_namespace("default")
+        from lakehouse.catalog import create_sample_tables
+        create_sample_tables(catalog)
+
+        insert_rows(catalog, "expenses", [
+            {"id": 6200, "category": "test", "amount": 10.0, "currency": "USD"},
+        ])
+
+        result = expire_snapshots(catalog, "expenses", older_than="30d")
+        assert result["expired"] == 0
+
+    def test_expire_older_than_iso_timestamp(self, tmp_path):
+        """Test expiring with ISO timestamp in the past (nothing to expire)."""
+        from pyiceberg.catalog.sql import SqlCatalog
+        catalog = SqlCatalog(
+            "expire_ts_test",
+            **{"uri": f"sqlite:///{tmp_path / 'c.db'}", "warehouse": f"file://{tmp_path / 'w'}"},
+        )
+        (tmp_path / "w").mkdir()
+        catalog.create_namespace("default")
+        from lakehouse.catalog import create_sample_tables
+        create_sample_tables(catalog)
+
+        insert_rows(catalog, "expenses", [
+            {"id": 6210, "category": "test", "amount": 10.0, "currency": "USD"},
+        ])
+
+        result = expire_snapshots(catalog, "expenses", older_than="2020-01-01T00:00:00")
+        assert result["expired"] == 0

--- a/tests/test_time_travel.py
+++ b/tests/test_time_travel.py
@@ -1,0 +1,112 @@
+"""Tests for time travel query support."""
+
+import datetime
+import time
+import pytest
+
+from lakehouse.catalog import insert_rows, get_snapshots, scan_as_of
+
+
+class TestTimeTravel:
+    """Test time travel features."""
+
+    def _insert_and_get_snapshot(self, test_catalog):
+        """Helper: insert data and return the snapshot ID."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 4000, "category": "original", "amount": 50.0, "currency": "USD"},
+        ])
+        snapshots = get_snapshots(test_catalog, "expenses")
+        return snapshots[-1]["snapshot_id"]
+
+    def test_list_snapshots_empty_table(self, test_catalog):
+        """Test listing snapshots for table with no data."""
+        snapshots = get_snapshots(test_catalog, "expenses")
+        assert isinstance(snapshots, list)
+        assert len(snapshots) == 0
+
+    def test_list_snapshots_after_insert(self, test_catalog):
+        """Test that insert creates a snapshot."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 4010, "category": "test", "amount": 10.0, "currency": "USD"},
+        ])
+
+        snapshots = get_snapshots(test_catalog, "expenses")
+        assert len(snapshots) >= 1
+        assert "snapshot_id" in snapshots[0]
+        assert "timestamp" in snapshots[0]
+
+    def test_list_snapshots_multiple(self, test_catalog):
+        """Test multiple snapshots after multiple writes."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 4020, "category": "first", "amount": 10.0, "currency": "USD"},
+        ])
+        insert_rows(test_catalog, "expenses", [
+            {"id": 4021, "category": "second", "amount": 20.0, "currency": "USD"},
+        ])
+
+        snapshots = get_snapshots(test_catalog, "expenses")
+        assert len(snapshots) >= 2
+
+    def test_list_snapshots_nonexistent_table(self, test_catalog):
+        """Test listing snapshots for non-existent table raises error."""
+        with pytest.raises(ValueError, match="not found"):
+            get_snapshots(test_catalog, "nonexistent")
+
+    def test_scan_as_of_snapshot_id(self, test_catalog):
+        """Test scanning at a specific snapshot ID."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 4030, "category": "v1", "amount": 10.0, "currency": "USD"},
+        ])
+        snapshots = get_snapshots(test_catalog, "expenses")
+        first_snap = snapshots[-1]["snapshot_id"]
+
+        # Make another change
+        insert_rows(test_catalog, "expenses", [
+            {"id": 4031, "category": "v2", "amount": 20.0, "currency": "USD"},
+        ])
+
+        # Scan at the first snapshot - should only have the first row
+        arrow = scan_as_of(test_catalog, "expenses", str(first_snap))
+        df = arrow.to_pandas()
+        ids = df["id"].tolist()
+        assert 4030 in ids
+        assert 4031 not in ids
+
+    def test_scan_as_of_timestamp(self, test_catalog):
+        """Test scanning at a specific timestamp."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 4040, "category": "before", "amount": 10.0, "currency": "USD"},
+        ])
+
+        # Use a future timestamp to include all data
+        future_ts = (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)).isoformat()
+        arrow = scan_as_of(test_catalog, "expenses", future_ts)
+        df = arrow.to_pandas()
+        assert 4040 in df["id"].tolist()
+
+    def test_scan_as_of_invalid_snapshot_id(self, test_catalog):
+        """Test scanning with non-existent snapshot ID."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 4050, "category": "test", "amount": 10.0, "currency": "USD"},
+        ])
+
+        with pytest.raises(ValueError, match="not found"):
+            scan_as_of(test_catalog, "expenses", "999999999999")
+
+    def test_scan_as_of_nonexistent_table(self, test_catalog):
+        """Test scanning non-existent table."""
+        with pytest.raises(ValueError, match="not found"):
+            scan_as_of(test_catalog, "nonexistent", "12345")
+
+    def test_snapshot_fields(self, test_catalog):
+        """Test that snapshot dicts have expected fields."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 4060, "category": "test", "amount": 10.0, "currency": "USD"},
+        ])
+
+        snapshots = get_snapshots(test_catalog, "expenses")
+        snap = snapshots[0]
+        assert "snapshot_id" in snap
+        assert "timestamp" in snap
+        assert "operation" in snap
+        assert isinstance(snap["snapshot_id"], int)

--- a/tests/test_upsert.py
+++ b/tests/test_upsert.py
@@ -1,0 +1,110 @@
+"""Tests for UPSERT operations."""
+
+import pytest
+
+from lakehouse.catalog import insert_rows, upsert_rows
+
+
+class TestUpsertRows:
+    """Test upsert_rows function."""
+
+    def test_upsert_insert_path(self, test_catalog, query_engine):
+        """Test upsert inserts when no key match."""
+        result = upsert_rows(test_catalog, "expenses", ["id"], [
+            {"id": 3000, "category": "new", "amount": 42.0, "currency": "USD"},
+        ])
+
+        assert result["inserted"] == 1
+        assert result["updated"] == 0
+
+        query_engine.refresh()
+        row = query_engine.execute("SELECT * FROM expenses WHERE id = 3000")
+        assert len(row) == 1
+        assert row.iloc[0]["category"] == "new"
+
+    def test_upsert_update_path(self, test_catalog, query_engine):
+        """Test upsert updates when key matches."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 3010, "category": "old", "amount": 10.0, "currency": "USD"},
+        ])
+
+        result = upsert_rows(test_catalog, "expenses", ["id"], [
+            {"id": 3010, "category": "updated", "amount": 99.0, "currency": "EUR"},
+        ])
+
+        assert result["updated"] == 1
+        assert result["inserted"] == 0
+
+        query_engine.refresh()
+        row = query_engine.execute("SELECT * FROM expenses WHERE id = 3010")
+        assert len(row) == 1
+        assert row.iloc[0]["category"] == "updated"
+        assert row.iloc[0]["amount"] == 99.0
+
+    def test_upsert_mixed(self, test_catalog, query_engine):
+        """Test upsert with both inserts and updates."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 3020, "category": "existing", "amount": 50.0, "currency": "USD"},
+        ])
+
+        result = upsert_rows(test_catalog, "expenses", ["id"], [
+            {"id": 3020, "category": "updated", "amount": 75.0, "currency": "USD"},
+            {"id": 3021, "category": "brand_new", "amount": 25.0, "currency": "EUR"},
+        ])
+
+        assert result["updated"] == 1
+        assert result["inserted"] == 1
+
+        query_engine.refresh()
+        rows = query_engine.execute("SELECT * FROM expenses WHERE id IN (3020, 3021) ORDER BY id")
+        assert len(rows) == 2
+        assert rows.iloc[0]["category"] == "updated"
+        assert rows.iloc[1]["category"] == "brand_new"
+
+    def test_upsert_into_empty_table(self, test_catalog, query_engine):
+        """Test upsert into empty table (all inserts)."""
+        result = upsert_rows(test_catalog, "expenses", ["id"], [
+            {"id": 3030, "category": "a", "amount": 10.0, "currency": "USD"},
+            {"id": 3031, "category": "b", "amount": 20.0, "currency": "USD"},
+        ])
+
+        assert result["inserted"] == 2
+        assert result["updated"] == 0
+
+    def test_upsert_empty_rows(self, test_catalog):
+        """Test upsert with empty rows returns zeros."""
+        result = upsert_rows(test_catalog, "expenses", ["id"], [])
+        assert result["inserted"] == 0
+        assert result["updated"] == 0
+
+    def test_upsert_empty_key_columns_raises_error(self, test_catalog):
+        """Test upsert with empty key_columns raises error."""
+        with pytest.raises(ValueError, match="key_columns must not be empty"):
+            upsert_rows(test_catalog, "expenses", [], [{"id": 1}])
+
+    def test_upsert_invalid_key_column_raises_error(self, test_catalog):
+        """Test upsert with non-existent key column raises error."""
+        with pytest.raises(ValueError, match="does not exist"):
+            upsert_rows(test_catalog, "expenses", ["nonexistent"], [{"id": 1}])
+
+    def test_upsert_nonexistent_table_raises_error(self, test_catalog):
+        """Test upsert into non-existent table raises error."""
+        with pytest.raises(ValueError, match="not found"):
+            upsert_rows(test_catalog, "nonexistent_table", ["id"], [{"id": 1}])
+
+    def test_upsert_preserves_unmatched_existing_rows(self, test_catalog, query_engine):
+        """Test that upsert preserves existing rows not in the upsert set."""
+        insert_rows(test_catalog, "expenses", [
+            {"id": 3040, "category": "keep", "amount": 100.0, "currency": "USD"},
+            {"id": 3041, "category": "target", "amount": 50.0, "currency": "USD"},
+        ])
+
+        upsert_rows(test_catalog, "expenses", ["id"], [
+            {"id": 3041, "category": "changed", "amount": 75.0, "currency": "EUR"},
+        ])
+
+        query_engine.refresh()
+        kept = query_engine.execute("SELECT * FROM expenses WHERE id = 3040")
+        assert len(kept) == 1
+        assert kept.iloc[0]["category"] == "keep"
+        assert kept.iloc[0]["amount"] == 100.0


### PR DESCRIPTION
## Summary
- Add 61 new tests across 6 test files: delete, upsert, schema evolution, time travel, snapshot management, and batch operations
- Fix `expire_snapshots` to use manual `by_id` expiration instead of PyIceberg's `.older_than()` which has state leakage across test runs
- All 83 tests pass (22 existing + 61 new)

## Test plan
- [x] `uv run python -m pytest tests/ -v` — 83 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)