### PR TITLE
Add Vortex dependency and basic I/O (#13)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pyarrow>=14.0.0",
     "sqlalchemy>=2.0.0",
     "tabulate>=0.9.0",
+    "vortex-data>=0.50.0",
 ]
 
 [project.scripts]

--- a/src/lakehouse/_vortex_compat.py
+++ b/src/lakehouse/_vortex_compat.py
@@ -1,0 +1,50 @@
+"""Compatibility shim for vortex-data + substrait version mismatch.
+
+vortex-data 0.58 imports from substrait.gen.proto.* but substrait >= 0.23
+moved those modules to substrait.* directly. This shim creates the expected
+module structure so vortex can import successfully.
+"""
+
+import importlib
+import sys
+import types
+
+
+def _patch_substrait():
+    """Patch substrait module to provide gen.proto.* aliases."""
+    if "substrait.gen.proto.algebra_pb2" in sys.modules:
+        return  # Already patched or not needed
+
+    _substrait = importlib.import_module("substrait")
+
+    # Check if gen.proto already exists (older substrait)
+    try:
+        importlib.import_module("substrait.gen.proto.algebra_pb2")
+        return
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    # Create gen package
+    gen = types.ModuleType("substrait.gen")
+    gen.__path__ = _substrait.__path__
+    sys.modules["substrait.gen"] = gen
+
+    # Create gen.proto package
+    proto = types.ModuleType("substrait.gen.proto")
+    proto.__path__ = _substrait.__path__
+    sys.modules["substrait.gen.proto"] = proto
+
+    # Map top-level protobuf modules
+    sys.modules["substrait.gen.proto.algebra_pb2"] = importlib.import_module("substrait.algebra_pb2")
+    sys.modules["substrait.gen.proto.extended_expression_pb2"] = importlib.import_module("substrait.extended_expression_pb2")
+    sys.modules["substrait.gen.proto.type_pb2"] = importlib.import_module("substrait.type_pb2")
+
+    # Map extensions subpackage
+    extensions = types.ModuleType("substrait.gen.proto.extensions")
+    extensions.__path__ = [p + "/extensions" for p in _substrait.__path__]
+    sys.modules["substrait.gen.proto.extensions"] = extensions
+
+    sys.modules["substrait.gen.proto.extensions.extensions_pb2"] = importlib.import_module("substrait.extensions.extensions_pb2")
+
+
+_patch_substrait()

--- a/src/lakehouse/vortex_io.py
+++ b/src/lakehouse/vortex_io.py
@@ -1,0 +1,109 @@
+"""Vortex file format I/O utilities.
+
+Provides read/write operations for Vortex files and Arrow <-> Vortex conversion.
+Uses the vortex-data Python bindings.
+"""
+
+from pathlib import Path
+
+import pyarrow as pa
+
+import lakehouse._vortex_compat  # noqa: F401 — patches substrait for vortex
+import vortex as vx
+
+
+def write_vortex(table: pa.Table, path: str | Path, *, compact: bool = False) -> dict:
+    """Write an Arrow table to a Vortex file.
+
+    Args:
+        table: PyArrow table to write
+        path: Output file path
+        compact: If True, optimize for smaller file size over read speed
+
+    Returns:
+        Dict with file path and size info
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if compact:
+        vx.io.VortexWriteOptions.compact().write_path(table, str(path))
+    else:
+        vx.io.write(table, str(path))
+
+    return {
+        "path": str(path),
+        "rows": table.num_rows,
+        "size_bytes": path.stat().st_size,
+    }
+
+
+def read_vortex(path: str | Path) -> pa.Table:
+    """Read a Vortex file into an Arrow table.
+
+    Args:
+        path: Path to the Vortex file
+
+    Returns:
+        PyArrow table with the file contents
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Vortex file not found: {path}")
+
+    vxf = vx.open(str(path))
+    array = vxf.scan().read_all()
+    return array.to_arrow_table()
+
+
+def arrow_to_vortex(table: pa.Table) -> "vx.Array":
+    """Convert an Arrow table to a Vortex array (in-memory).
+
+    Args:
+        table: PyArrow table to convert
+
+    Returns:
+        Vortex array
+    """
+    return vx.array(table)
+
+
+def vortex_to_arrow(array: "vx.Array") -> pa.Table:
+    """Convert a Vortex array to an Arrow table (in-memory).
+
+    Args:
+        array: Vortex array to convert
+
+    Returns:
+        PyArrow table
+    """
+    return array.to_arrow_table()
+
+
+def vortex_file_info(path: str | Path) -> dict:
+    """Get metadata about a Vortex file without reading all data.
+
+    Args:
+        path: Path to the Vortex file
+
+    Returns:
+        Dict with file metadata
+
+    Raises:
+        FileNotFoundError: If the file doesn't exist
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Vortex file not found: {path}")
+
+    vxf = vx.open(str(path))
+    dtype = vxf.dtype
+
+    return {
+        "path": str(path),
+        "size_bytes": path.stat().st_size,
+        "dtype": str(dtype),
+    }

--- a/tests/test_vortex_io.py
+++ b/tests/test_vortex_io.py
@@ -1,0 +1,137 @@
+"""Tests for Vortex I/O utilities."""
+
+import pytest
+import pyarrow as pa
+
+from lakehouse.vortex_io import (
+    write_vortex,
+    read_vortex,
+    arrow_to_vortex,
+    vortex_to_arrow,
+    vortex_file_info,
+)
+
+
+@pytest.fixture
+def sample_table():
+    """Create a sample Arrow table with various types."""
+    return pa.table({
+        "id": pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+        "name": pa.array(["alice", "bob", "charlie", "diana", "eve"], type=pa.string()),
+        "amount": pa.array([10.5, 20.3, 30.1, 40.9, 50.7], type=pa.float64()),
+    })
+
+
+class TestWriteVortex:
+    """Test write_vortex function."""
+
+    def test_write_creates_file(self, tmp_path, sample_table):
+        """Test that write creates a .vortex file."""
+        path = tmp_path / "out.vortex"
+        result = write_vortex(sample_table, path)
+        assert path.exists()
+        assert result["rows"] == 5
+        assert result["size_bytes"] > 0
+
+    def test_write_creates_parent_dirs(self, tmp_path, sample_table):
+        """Test that write creates parent directories."""
+        path = tmp_path / "sub" / "dir" / "out.vortex"
+        write_vortex(sample_table, path)
+        assert path.exists()
+
+    def test_write_compact_mode(self, tmp_path, sample_table):
+        """Test compact write produces a file."""
+        path = tmp_path / "compact.vortex"
+        result = write_vortex(sample_table, path, compact=True)
+        assert path.exists()
+        assert result["rows"] == 5
+
+    def test_write_string_path(self, tmp_path, sample_table):
+        """Test write with string path."""
+        path = str(tmp_path / "str.vortex")
+        result = write_vortex(sample_table, path)
+        assert result["path"] == path
+
+
+class TestReadVortex:
+    """Test read_vortex function."""
+
+    def test_roundtrip(self, tmp_path, sample_table):
+        """Test write then read preserves data."""
+        path = tmp_path / "rt.vortex"
+        write_vortex(sample_table, path)
+        result = read_vortex(path)
+
+        assert result.num_rows == sample_table.num_rows
+        assert result.num_columns == sample_table.num_columns
+        assert result.column("id").to_pylist() == sample_table.column("id").to_pylist()
+        assert result.column("name").to_pylist() == sample_table.column("name").to_pylist()
+
+    def test_read_nonexistent_raises(self, tmp_path):
+        """Test reading non-existent file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            read_vortex(tmp_path / "nope.vortex")
+
+    def test_roundtrip_with_nulls(self, tmp_path):
+        """Test roundtrip with null values."""
+        table = pa.table({
+            "id": pa.array([1, 2, 3], type=pa.int64()),
+            "val": pa.array([10.0, None, 30.0], type=pa.float64()),
+        })
+        path = tmp_path / "nulls.vortex"
+        write_vortex(table, path)
+        result = read_vortex(path)
+        assert result.column("val").to_pylist() == [10.0, None, 30.0]
+
+    def test_roundtrip_large_table(self, tmp_path):
+        """Test roundtrip with larger dataset."""
+        n = 10_000
+        table = pa.table({
+            "id": pa.array(list(range(n)), type=pa.int64()),
+            "val": pa.array([float(i) for i in range(n)], type=pa.float64()),
+        })
+        path = tmp_path / "large.vortex"
+        write_vortex(table, path)
+        result = read_vortex(path)
+        assert result.num_rows == n
+
+
+class TestArrowConversion:
+    """Test in-memory Arrow <-> Vortex conversion."""
+
+    def test_arrow_to_vortex(self, sample_table):
+        """Test converting Arrow table to Vortex array."""
+        arr = arrow_to_vortex(sample_table)
+        assert len(arr) == 5
+        assert arr.nbytes > 0
+
+    def test_vortex_to_arrow(self, sample_table):
+        """Test converting Vortex array back to Arrow table."""
+        arr = arrow_to_vortex(sample_table)
+        result = vortex_to_arrow(arr)
+        assert result.num_rows == 5
+        assert result.column("id").to_pylist() == [1, 2, 3, 4, 5]
+
+    def test_roundtrip_in_memory(self, sample_table):
+        """Test full in-memory roundtrip."""
+        arr = arrow_to_vortex(sample_table)
+        result = vortex_to_arrow(arr)
+        assert result.column("name").to_pylist() == sample_table.column("name").to_pylist()
+        assert result.column("amount").to_pylist() == sample_table.column("amount").to_pylist()
+
+
+class TestVortexFileInfo:
+    """Test vortex_file_info function."""
+
+    def test_file_info(self, tmp_path, sample_table):
+        """Test getting file metadata."""
+        path = tmp_path / "info.vortex"
+        write_vortex(sample_table, path)
+        info = vortex_file_info(path)
+        assert info["size_bytes"] > 0
+        assert "dtype" in info
+
+    def test_file_info_nonexistent_raises(self, tmp_path):
+        """Test info on non-existent file raises."""
+        with pytest.raises(FileNotFoundError):
+            vortex_file_info(tmp_path / "nope.vortex")


### PR DESCRIPTION
## Summary
- Add `vortex-data` dependency to pyproject.toml
- Create `src/lakehouse/vortex_io.py` with Arrow <-> Vortex conversion and file I/O
- Create `src/lakehouse/_vortex_compat.py` shim for substrait version mismatch
- Add 13 tests covering write, read, roundtrip, nulls, large tables, in-memory conversion, and file info

## API
```python
from lakehouse.vortex_io import write_vortex, read_vortex, arrow_to_vortex, vortex_to_arrow, vortex_file_info
```

## Test plan
- [x] `uv run python -m pytest tests/ -v` — 96 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)