### PR TITLE
Integrate Vortex with DuckDB query engine

### DIFF
--- a/tests/test_vortex_query.py
+++ b/tests/test_vortex_query.py
@@ -1,0 +1,212 @@
+"""Tests for Vortex integration with DuckDB query engine."""
+
+import pytest
+import pyarrow as pa
+
+from lakehouse.vortex_io import write_vortex
+from lakehouse.query import QueryEngine
+
+
+@pytest.fixture
+def vortex_file(tmp_path):
+    """Create a sample Vortex file for testing."""
+    table = pa.table({
+        "id": pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+        "name": pa.array(["alice", "bob", "charlie", "diana", "eve"], type=pa.string()),
+        "amount": pa.array([10.5, 20.3, 30.1, 40.9, 50.7], type=pa.float64()),
+    })
+    path = tmp_path / "test_data.vortex"
+    write_vortex(table, path)
+    return path
+
+
+@pytest.fixture
+def engine():
+    """Create a standalone QueryEngine (no catalog needed for Vortex queries)."""
+    return QueryEngine.__new__(QueryEngine)
+
+
+class TestHasVortex:
+    """Test DuckDB Vortex extension detection."""
+
+    def test_has_vortex_returns_bool(self):
+        """Test that has_vortex returns a boolean."""
+        engine = QueryEngine.__new__(QueryEngine)
+        engine.catalog = None
+        engine.warehouse = None
+        engine._conn = None
+        engine._vortex_available = None
+
+        # Accessing has_vortex triggers connection + extension detection
+        result = engine.has_vortex
+        assert isinstance(result, bool)
+
+    def test_has_vortex_cached(self):
+        """Test that _vortex_available is cached after first check."""
+        engine = QueryEngine.__new__(QueryEngine)
+        engine._vortex_available = True
+        assert engine.has_vortex is True
+
+        engine._vortex_available = False
+        assert engine.has_vortex is False
+
+
+class TestQueryVortex:
+    """Test query_vortex method for direct Vortex file queries."""
+
+    def test_select_all(self, vortex_file):
+        """Test SELECT * from a Vortex file."""
+        engine = QueryEngine.__new__(QueryEngine)
+        engine._conn = None
+        engine._vortex_available = None
+
+        result = engine.query_vortex("SELECT * FROM data", vortex_file)
+        assert len(result) == 5
+        assert "id" in result.columns
+        assert "name" in result.columns
+        assert "amount" in result.columns
+
+    def test_select_with_filter(self, vortex_file):
+        """Test SELECT with WHERE clause."""
+        engine = QueryEngine.__new__(QueryEngine)
+        engine._conn = None
+        engine._vortex_available = None
+
+        result = engine.query_vortex("SELECT * FROM data WHERE amount > 25.0", vortex_file)
+        assert len(result) == 3
+        assert all(v > 25.0 for v in result["amount"].tolist())
+
+    def test_aggregate_query(self, vortex_file):
+        """Test aggregate query on Vortex file."""
+        engine = QueryEngine.__new__(QueryEngine)
+        engine._conn = None
+        engine._vortex_available = None
+
+        result = engine.query_vortex("SELECT count(*) as cnt, sum(amount) as total FROM data", vortex_file)
+        assert len(result) == 1
+        assert result["cnt"].iloc[0] == 5
+
+    def test_custom_table_name(self, vortex_file):
+        """Test using a custom table name."""
+        engine = QueryEngine.__new__(QueryEngine)
+        engine._conn = None
+        engine._vortex_available = None
+
+        result = engine.query_vortex(
+            "SELECT * FROM my_table WHERE id <= 2",
+            vortex_file,
+            table_name="my_table",
+        )
+        assert len(result) == 2
+
+    def test_max_rows_limit(self, vortex_file):
+        """Test that max_rows limits results."""
+        engine = QueryEngine.__new__(QueryEngine)
+        engine._conn = None
+        engine._vortex_available = None
+
+        result = engine.query_vortex("SELECT * FROM data", vortex_file, max_rows=3)
+        assert len(result) == 3
+
+    def test_nonexistent_file_raises(self, tmp_path):
+        """Test querying non-existent file raises FileNotFoundError."""
+        engine = QueryEngine.__new__(QueryEngine)
+        engine._conn = None
+        engine._vortex_available = None
+
+        with pytest.raises(FileNotFoundError):
+            engine.query_vortex("SELECT * FROM data", tmp_path / "nope.vortex")
+
+    def test_order_by(self, vortex_file):
+        """Test ORDER BY on Vortex file."""
+        engine = QueryEngine.__new__(QueryEngine)
+        engine._conn = None
+        engine._vortex_available = None
+
+        result = engine.query_vortex(
+            "SELECT name, amount FROM data ORDER BY amount DESC LIMIT 3",
+            vortex_file,
+        )
+        assert len(result) == 3
+        amounts = result["amount"].tolist()
+        assert amounts == sorted(amounts, reverse=True)
+
+
+class TestRegisterVortex:
+    """Test register_vortex method."""
+
+    def test_register_and_query(self, vortex_file):
+        """Test registering a Vortex file and querying it."""
+        engine = QueryEngine.__new__(QueryEngine)
+        engine.catalog = None
+        engine.warehouse = None
+        engine._conn = None
+        engine._vortex_available = None
+
+        engine.register_vortex("test_table", vortex_file)
+        conn = engine._get_connection()
+
+        result = conn.execute("SELECT count(*) as cnt FROM test_table").fetchdf()
+        assert result["cnt"].iloc[0] == 5
+
+    def test_register_nonexistent_raises(self, tmp_path):
+        """Test registering non-existent file raises FileNotFoundError."""
+        engine = QueryEngine.__new__(QueryEngine)
+        engine.catalog = None
+        engine.warehouse = None
+        engine._conn = None
+        engine._vortex_available = None
+
+        with pytest.raises(FileNotFoundError):
+            engine.register_vortex("nope", tmp_path / "nope.vortex")
+
+    def test_register_multiple_files(self, tmp_path):
+        """Test registering multiple Vortex files."""
+        # Create two Vortex files
+        t1 = pa.table({"x": pa.array([1, 2, 3], type=pa.int64())})
+        t2 = pa.table({"y": pa.array([10, 20], type=pa.int64())})
+
+        p1 = tmp_path / "t1.vortex"
+        p2 = tmp_path / "t2.vortex"
+        write_vortex(t1, p1)
+        write_vortex(t2, p2)
+
+        engine = QueryEngine.__new__(QueryEngine)
+        engine.catalog = None
+        engine.warehouse = None
+        engine._conn = None
+        engine._vortex_available = None
+
+        engine.register_vortex("table_a", p1)
+        engine.register_vortex("table_b", p2)
+
+        conn = engine._get_connection()
+        r1 = conn.execute("SELECT count(*) as cnt FROM table_a").fetchdf()
+        r2 = conn.execute("SELECT count(*) as cnt FROM table_b").fetchdf()
+        assert r1["cnt"].iloc[0] == 3
+        assert r2["cnt"].iloc[0] == 2
+
+    def test_register_overwrite(self, tmp_path):
+        """Test re-registering with same name replaces the table."""
+        t1 = pa.table({"x": pa.array([1, 2], type=pa.int64())})
+        t2 = pa.table({"x": pa.array([10, 20, 30], type=pa.int64())})
+
+        p1 = tmp_path / "v1.vortex"
+        p2 = tmp_path / "v2.vortex"
+        write_vortex(t1, p1)
+        write_vortex(t2, p2)
+
+        engine = QueryEngine.__new__(QueryEngine)
+        engine.catalog = None
+        engine.warehouse = None
+        engine._conn = None
+        engine._vortex_available = None
+
+        engine.register_vortex("data", p1)
+        conn = engine._get_connection()
+        r1 = conn.execute("SELECT count(*) as cnt FROM data").fetchdf()
+        assert r1["cnt"].iloc[0] == 2
+
+        engine.register_vortex("data", p2)
+        r2 = conn.execute("SELECT count(*) as cnt FROM data").fetchdf()
+        assert r2["cnt"].iloc[0] == 3

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -433,6 +433,7 @@ dependencies = [
     { name = "rich" },
     { name = "sqlalchemy" },
     { name = "tabulate" },
+    { name = "vortex-data" },
 ]
 
 [package.dev-dependencies]
@@ -452,6 +453,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
+    { name = "vortex-data", specifier = ">=0.50.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -798,6 +800,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
 ]
 
 [[package]]
@@ -1390,6 +1407,7 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/f9/5e4491e5ccf42f5d9cfc663741d261b3e6e1683ae7812114e7636409fcc6/sqlalchemy-2.0.45.tar.gz", hash = "sha256:1632a4bda8d2d25703fdad6363058d882541bdaaee0e5e3ddfa0cd3229efce88", size = 9869912, upload-time = "2025-12-09T21:05:16.737Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/1c/769552a9d840065137272ebe86ffbb0bc92b0f1e0a68ee5266a225f8cd7b/sqlalchemy-2.0.45-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e90a344c644a4fa871eb01809c32096487928bd2038bf10f3e4515cb688cc56", size = 2153860, upload-time = "2025-12-10T20:03:23.843Z" },
     { url = "https://files.pythonhosted.org/packages/f3/f8/9be54ff620e5b796ca7b44670ef58bc678095d51b0e89d6e3102ea468216/sqlalchemy-2.0.45-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8c8b41b97fba5f62349aa285654230296829672fc9939cd7f35aab246d1c08b", size = 3309379, upload-time = "2025-12-09T22:06:07.461Z" },
     { url = "https://files.pythonhosted.org/packages/f6/2b/60ce3ee7a5ae172bfcd419ce23259bb874d2cddd44f67c5df3760a1e22f9/sqlalchemy-2.0.45-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12c694ed6468333a090d2f60950e4250b928f457e4962389553d6ba5fe9951ac", size = 3309948, upload-time = "2025-12-09T22:09:57.643Z" },
     { url = "https://files.pythonhosted.org/packages/a3/42/bac8d393f5db550e4e466d03d16daaafd2bad1f74e48c12673fb499a7fc1/sqlalchemy-2.0.45-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f7d27a1d977a1cfef38a0e2e1ca86f09c4212666ce34e6ae542f3ed0a33bc606", size = 3261239, upload-time = "2025-12-09T22:06:08.879Z" },
@@ -1456,6 +1474,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206, upload-time = "2023-03-10T12:50:27.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917, upload-time = "2023-03-10T12:50:17.242Z" },
+]
+
+[[package]]
+name = "substrait"
+version = "0.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+    { name = "substrait-protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/73/0f3d6a1df07c7868533e78467e8b61a1559844a988c2cd0565aafa7773c2/substrait-0.27.0.tar.gz", hash = "sha256:73d6f90465c8138a10fb912c669a840abb95b04060c7d31faf331e38901bfb0a", size = 173217, upload-time = "2026-01-29T22:51:11.743Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/0b/d048fe689b39f35fac47bd5468b0c1f9deaa265ba5379015b8f1c3e908c3/substrait-0.27.0-py3-none-any.whl", hash = "sha256:09fbb748d61ab9d02149e518c8d282ca4db8caebfbe60c1660b23a28007bbc85", size = 90516, upload-time = "2026-01-29T22:51:10.705Z" },
+]
+
+[[package]]
+name = "substrait-protobuf"
+version = "0.79.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/8d/0d7ff0e56fdf341182729da4ce5754712ad3b950e0e404ec2fa53f46627b/substrait_protobuf-0.79.0.tar.gz", hash = "sha256:f1bf8641eb3ee785f4affd4f728568958deda2bb1ededa09f02f2118229616d4", size = 74840, upload-time = "2026-01-29T00:08:55.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/27/24e16471dc7b5986cd2af0d5aab9b12347fb835840fb2320b1b2375e53a8/substrait_protobuf-0.79.0-py3-none-any.whl", hash = "sha256:6f710459569be0b92661e16a2d180a9f2a03853c3ef0154a0c6c8a9aef365ffa", size = 83741, upload-time = "2026-01-29T00:08:54.03Z" },
 ]
 
 [[package]]
@@ -1526,4 +1569,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02", size = 68109, upload-time = "2025-10-18T13:46:42.958Z" },
+]
+
+[[package]]
+name = "vortex-data"
+version = "0.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyarrow" },
+    { name = "substrait" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/73/9d17423aafe99c3948948e52ec22a473c2a0d2a2eb6972689c01fec2ef19/vortex_data-0.58.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:92f1820ea35930c3ec0feaf8a898ef973a924190dabb9ea474c889de62db6b4a", size = 13943552, upload-time = "2026-01-07T17:27:59.17Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ba/13e152d0afba6177b24fa18ad111d2d7ad05eb3200570cb41aae2fccf243/vortex_data-0.58.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:3ee969bf30c96ce4d19a845b655dfd2e293bde1e75f98c9d008b5a63d262d936", size = 13057447, upload-time = "2026-01-07T17:28:01.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2d/36342e1ecc2db25ac737b74ae0e3adeea9146acfc238d2fc2e02ddfd2c8f/vortex_data-0.58.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74be8388b7b4abe34dd2a2a8edadcf3789cd4811a8d58e9d212abf3800361216", size = 12074895, upload-time = "2026-01-07T17:28:04.158Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9c/ca7075dde3b86c3a3a4cd24545e1bc4fc7490ceb6c3c5ecaee4ba0e465bb/vortex_data-0.58.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ae73348e456c9ad72f8070dba9546186fbd2c00f492a713492fedd504457b3a", size = 12973171, upload-time = "2026-01-07T17:28:07.134Z" },
 ]


### PR DESCRIPTION
## Summary
- Adds Vortex file support to the DuckDB query engine with a dual-path strategy: native DuckDB Vortex extension when available, Arrow bridge fallback otherwise
- Adds `query-vortex` CLI command and `query_vortex` MCP tool for querying Vortex files directly via SQL
- Adds `register_vortex()` to register Vortex files as queryable tables in the engine, and `has_vortex` property for extension detection

Closes #15

## Changes
- **`query.py`**: Added `_load_vortex_extension()`, `has_vortex` property, `register_vortex()`, `query_vortex()` methods; handle `None` catalog in `_register_tables()`
- **`cli.py`**: Added `query-vortex` command with format/table-name/max-rows options
- **`server.py`**: Added `query_vortex` MCP tool with sql/vortex_path/table_name/max_rows params
- **`tests/test_vortex_query.py`**: 13 tests covering extension detection, Vortex file queries, and table registration

## Test plan
- [x] All 122 tests pass (109 existing + 13 new)
- [ ] Verify `lakehouse query-vortex data.vortex "SELECT * FROM data"` works end-to-end
- [ ] Test MCP tool via Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)