### PR TITLE
Add table-level format configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "tabulate>=0.9.0",
     "vortex-data>=0.50.0",
+    "tomli-w>=1.2.0",
 ]
 
 [project.scripts]

--- a/src/lakehouse/config.py
+++ b/src/lakehouse/config.py
@@ -1,0 +1,218 @@
+"""Configuration management for Iceberg Lakehouse.
+
+Supports a TOML config file at ~/.lakehouse/config.toml with global defaults
+and per-table format overrides.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+import tomli_w
+
+
+DEFAULT_CONFIG_PATH = Path.home() / ".lakehouse" / "config.toml"
+
+VALID_FORMATS = {"parquet", "vortex"}
+
+
+def _load_config(config_path: Optional[Path] = None) -> dict:
+    """Load config from TOML file."""
+    path = config_path or DEFAULT_CONFIG_PATH
+    if not path.exists():
+        return {}
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _save_config(data: dict, config_path: Optional[Path] = None) -> None:
+    """Save config to TOML file."""
+    path = config_path or DEFAULT_CONFIG_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as f:
+        tomli_w.dump(data, f)
+
+
+def get_default_format(config_path: Optional[Path] = None) -> str:
+    """Get the global default file format.
+
+    Returns:
+        Format string ('parquet' or 'vortex'). Defaults to 'parquet'.
+    """
+    config = _load_config(config_path)
+    return config.get("defaults", {}).get("file_format", "parquet")
+
+
+def set_default_format(fmt: str, config_path: Optional[Path] = None) -> None:
+    """Set the global default file format.
+
+    Args:
+        fmt: Format string ('parquet' or 'vortex')
+        config_path: Optional config file path
+
+    Raises:
+        ValueError: If format is not valid
+    """
+    if fmt not in VALID_FORMATS:
+        raise ValueError(f"Invalid format '{fmt}'. Must be one of: {', '.join(sorted(VALID_FORMATS))}")
+
+    config = _load_config(config_path)
+    if "defaults" not in config:
+        config["defaults"] = {}
+    config["defaults"]["file_format"] = fmt
+    _save_config(config, config_path)
+
+
+def get_table_format(
+    table_name: str,
+    config_path: Optional[Path] = None,
+) -> str:
+    """Get the configured file format for a specific table.
+
+    Resolution order:
+    1. Per-table config override
+    2. Global default
+    3. 'parquet' (hardcoded fallback)
+
+    Args:
+        table_name: Table name (short name without namespace)
+
+    Returns:
+        Format string ('parquet' or 'vortex')
+    """
+    config = _load_config(config_path)
+
+    # Check per-table override
+    short_name = table_name.split(".")[-1] if "." in table_name else table_name
+    table_fmt = config.get("tables", {}).get(short_name, {}).get("file_format")
+    if table_fmt and table_fmt in VALID_FORMATS:
+        return table_fmt
+
+    # Fall back to global default
+    return config.get("defaults", {}).get("file_format", "parquet")
+
+
+def set_table_format(
+    table_name: str,
+    fmt: str,
+    config_path: Optional[Path] = None,
+) -> None:
+    """Set the file format for a specific table.
+
+    Args:
+        table_name: Table name (short name without namespace)
+        fmt: Format string ('parquet' or 'vortex')
+        config_path: Optional config file path
+
+    Raises:
+        ValueError: If format is not valid
+    """
+    if fmt not in VALID_FORMATS:
+        raise ValueError(f"Invalid format '{fmt}'. Must be one of: {', '.join(sorted(VALID_FORMATS))}")
+
+    short_name = table_name.split(".")[-1] if "." in table_name else table_name
+    config = _load_config(config_path)
+
+    if "tables" not in config:
+        config["tables"] = {}
+    if short_name not in config["tables"]:
+        config["tables"][short_name] = {}
+
+    config["tables"][short_name]["file_format"] = fmt
+    _save_config(config, config_path)
+
+
+def get_config_summary(config_path: Optional[Path] = None) -> dict:
+    """Get a summary of all configuration.
+
+    Returns:
+        Dict with 'default_format' and 'table_overrides'
+    """
+    config = _load_config(config_path)
+    default_fmt = config.get("defaults", {}).get("file_format", "parquet")
+
+    table_overrides = {}
+    for table_name, table_config in config.get("tables", {}).items():
+        fmt = table_config.get("file_format")
+        if fmt:
+            table_overrides[table_name] = fmt
+
+    return {
+        "default_format": default_fmt,
+        "table_overrides": table_overrides,
+    }
+
+
+def resolve_format(
+    table_name: str,
+    override: Optional[str] = None,
+    config_path: Optional[Path] = None,
+) -> str:
+    """Resolve the effective file format for a table.
+
+    Resolution order:
+    1. Write-time override (if provided)
+    2. Iceberg table property 'write.format.default' (checked externally)
+    3. Per-table config
+    4. Global default
+    5. 'parquet' (hardcoded fallback)
+
+    Note: Iceberg table property is not checked here — use
+    resolve_format_with_table() for full resolution including table properties.
+
+    Args:
+        table_name: Table name
+        override: Write-time format override
+        config_path: Optional config file path
+
+    Returns:
+        Resolved format string
+    """
+    if override:
+        if override not in VALID_FORMATS:
+            raise ValueError(f"Invalid format '{override}'. Must be one of: {', '.join(sorted(VALID_FORMATS))}")
+        return override
+
+    return get_table_format(table_name, config_path)
+
+
+def resolve_format_with_table(
+    table_name: str,
+    table_properties: Optional[dict] = None,
+    override: Optional[str] = None,
+    config_path: Optional[Path] = None,
+) -> str:
+    """Resolve the effective file format including Iceberg table properties.
+
+    Resolution order:
+    1. Write-time override
+    2. Iceberg table property 'write.format.default'
+    3. Per-table config
+    4. Global default
+    5. 'parquet' (hardcoded fallback)
+
+    Args:
+        table_name: Table name
+        table_properties: Iceberg table properties dict
+        override: Write-time format override
+        config_path: Optional config file path
+
+    Returns:
+        Resolved format string
+    """
+    if override:
+        if override not in VALID_FORMATS:
+            raise ValueError(f"Invalid format '{override}'. Must be one of: {', '.join(sorted(VALID_FORMATS))}")
+        return override
+
+    # Check Iceberg table property
+    if table_properties:
+        prop_fmt = table_properties.get("write.format.default")
+        if prop_fmt and prop_fmt.lower() in VALID_FORMATS:
+            return prop_fmt.lower()
+
+    return get_table_format(table_name, config_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,185 @@
+"""Tests for format configuration management."""
+
+import pytest
+
+from lakehouse.config import (
+    get_default_format,
+    set_default_format,
+    get_table_format,
+    set_table_format,
+    get_config_summary,
+    resolve_format,
+    resolve_format_with_table,
+    VALID_FORMATS,
+)
+
+
+@pytest.fixture
+def config_path(tmp_path):
+    """Return a temporary config file path."""
+    return tmp_path / "config.toml"
+
+
+class TestDefaultFormat:
+    """Test global default format management."""
+
+    def test_default_is_parquet(self, config_path):
+        """Test that default format is parquet when no config exists."""
+        assert get_default_format(config_path) == "parquet"
+
+    def test_set_default_format(self, config_path):
+        """Test setting the global default format."""
+        set_default_format("vortex", config_path)
+        assert get_default_format(config_path) == "vortex"
+
+    def test_set_default_format_parquet(self, config_path):
+        """Test setting format back to parquet."""
+        set_default_format("vortex", config_path)
+        set_default_format("parquet", config_path)
+        assert get_default_format(config_path) == "parquet"
+
+    def test_set_invalid_format_raises(self, config_path):
+        """Test that invalid format raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid format"):
+            set_default_format("csv", config_path)
+
+    def test_config_file_created(self, config_path):
+        """Test that setting format creates the config file."""
+        assert not config_path.exists()
+        set_default_format("vortex", config_path)
+        assert config_path.exists()
+
+
+class TestTableFormat:
+    """Test per-table format configuration."""
+
+    def test_table_format_defaults_to_global(self, config_path):
+        """Test that table format falls back to global default."""
+        assert get_table_format("expenses", config_path) == "parquet"
+
+    def test_table_format_uses_global_when_set(self, config_path):
+        """Test that table format uses global default when changed."""
+        set_default_format("vortex", config_path)
+        assert get_table_format("expenses", config_path) == "vortex"
+
+    def test_set_table_format_override(self, config_path):
+        """Test setting a per-table format override."""
+        set_table_format("expenses", "vortex", config_path)
+        assert get_table_format("expenses", config_path) == "vortex"
+
+    def test_table_override_takes_priority(self, config_path):
+        """Test that per-table format overrides global default."""
+        set_default_format("parquet", config_path)
+        set_table_format("expenses", "vortex", config_path)
+        assert get_table_format("expenses", config_path) == "vortex"
+        # Other tables still use global default
+        assert get_table_format("health", config_path) == "parquet"
+
+    def test_set_table_invalid_format_raises(self, config_path):
+        """Test that invalid table format raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid format"):
+            set_table_format("expenses", "csv", config_path)
+
+    def test_qualified_table_name_stripped(self, config_path):
+        """Test that namespace is stripped from qualified names."""
+        set_table_format("default.expenses", "vortex", config_path)
+        assert get_table_format("expenses", config_path) == "vortex"
+        assert get_table_format("default.expenses", config_path) == "vortex"
+
+
+class TestConfigSummary:
+    """Test get_config_summary."""
+
+    def test_empty_config(self, config_path):
+        """Test summary with no config file."""
+        summary = get_config_summary(config_path)
+        assert summary["default_format"] == "parquet"
+        assert summary["table_overrides"] == {}
+
+    def test_full_config(self, config_path):
+        """Test summary with global and table overrides."""
+        set_default_format("vortex", config_path)
+        set_table_format("expenses", "parquet", config_path)
+        set_table_format("health", "vortex", config_path)
+
+        summary = get_config_summary(config_path)
+        assert summary["default_format"] == "vortex"
+        assert summary["table_overrides"] == {
+            "expenses": "parquet",
+            "health": "vortex",
+        }
+
+
+class TestResolveFormat:
+    """Test format resolution logic."""
+
+    def test_override_takes_priority(self, config_path):
+        """Test that write-time override takes highest priority."""
+        set_default_format("parquet", config_path)
+        set_table_format("expenses", "parquet", config_path)
+        assert resolve_format("expenses", override="vortex", config_path=config_path) == "vortex"
+
+    def test_invalid_override_raises(self, config_path):
+        """Test that invalid override raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid format"):
+            resolve_format("expenses", override="csv", config_path=config_path)
+
+    def test_table_config_used(self, config_path):
+        """Test that per-table config is used when no override."""
+        set_table_format("expenses", "vortex", config_path)
+        assert resolve_format("expenses", config_path=config_path) == "vortex"
+
+    def test_global_fallback(self, config_path):
+        """Test fallback to global default."""
+        set_default_format("vortex", config_path)
+        assert resolve_format("expenses", config_path=config_path) == "vortex"
+
+
+class TestResolveFormatWithTable:
+    """Test format resolution including Iceberg table properties."""
+
+    def test_override_highest_priority(self, config_path):
+        """Test write-time override beats everything."""
+        props = {"write.format.default": "parquet"}
+        set_table_format("expenses", "parquet", config_path)
+        assert resolve_format_with_table(
+            "expenses", props, override="vortex", config_path=config_path
+        ) == "vortex"
+
+    def test_table_property_beats_config(self, config_path):
+        """Test Iceberg table property beats config file."""
+        props = {"write.format.default": "vortex"}
+        set_default_format("parquet", config_path)
+        assert resolve_format_with_table(
+            "expenses", props, config_path=config_path
+        ) == "vortex"
+
+    def test_config_used_when_no_property(self, config_path):
+        """Test config file used when no table property."""
+        set_table_format("expenses", "vortex", config_path)
+        assert resolve_format_with_table(
+            "expenses", {}, config_path=config_path
+        ) == "vortex"
+
+    def test_full_fallback_chain(self, config_path):
+        """Test full resolution chain."""
+        # No override, no table property, no table config -> global default
+        set_default_format("vortex", config_path)
+        assert resolve_format_with_table(
+            "expenses", None, config_path=config_path
+        ) == "vortex"
+
+    def test_case_insensitive_property(self, config_path):
+        """Test that table property value is case-insensitive."""
+        props = {"write.format.default": "Vortex"}
+        assert resolve_format_with_table(
+            "expenses", props, config_path=config_path
+        ) == "vortex"
+
+    def test_invalid_property_ignored(self, config_path):
+        """Test that invalid table property is ignored."""
+        props = {"write.format.default": "csv"}
+        set_default_format("vortex", config_path)
+        assert resolve_format_with_table(
+            "expenses", props, config_path=config_path
+        ) == "vortex"

--- a/tests/test_table_properties.py
+++ b/tests/test_table_properties.py
@@ -1,0 +1,92 @@
+"""Tests for Iceberg table property management."""
+
+import pytest
+
+from lakehouse.catalog import (
+    get_table_property,
+    set_table_property,
+    remove_table_property,
+)
+
+
+class TestGetTableProperty:
+    """Test get_table_property function."""
+
+    def test_get_nonexistent_property(self, test_catalog):
+        """Test getting a property that doesn't exist returns None."""
+        result = get_table_property(test_catalog, "expenses", "write.format.default")
+        assert result is None
+
+    def test_get_after_set(self, test_catalog):
+        """Test getting a property after setting it."""
+        set_table_property(test_catalog, "expenses", "write.format.default", "vortex")
+        result = get_table_property(test_catalog, "expenses", "write.format.default")
+        assert result == "vortex"
+
+    def test_get_nonexistent_table_raises(self, test_catalog):
+        """Test getting property from non-existent table raises."""
+        with pytest.raises(ValueError, match="not found"):
+            get_table_property(test_catalog, "nonexistent", "some.key")
+
+    def test_get_with_namespace(self, test_catalog):
+        """Test getting property with qualified table name."""
+        set_table_property(test_catalog, "default.expenses", "custom.key", "value1")
+        result = get_table_property(test_catalog, "default.expenses", "custom.key")
+        assert result == "value1"
+
+
+class TestSetTableProperty:
+    """Test set_table_property function."""
+
+    def test_set_property(self, test_catalog):
+        """Test setting a table property."""
+        msg = set_table_property(test_catalog, "expenses", "write.format.default", "vortex")
+        assert "write.format.default" in msg
+        assert "vortex" in msg
+
+    def test_set_overwrites_existing(self, test_catalog):
+        """Test setting a property that already exists overwrites it."""
+        set_table_property(test_catalog, "expenses", "custom.key", "value1")
+        set_table_property(test_catalog, "expenses", "custom.key", "value2")
+        result = get_table_property(test_catalog, "expenses", "custom.key")
+        assert result == "value2"
+
+    def test_set_multiple_properties(self, test_catalog):
+        """Test setting multiple properties."""
+        set_table_property(test_catalog, "expenses", "key1", "val1")
+        set_table_property(test_catalog, "expenses", "key2", "val2")
+        assert get_table_property(test_catalog, "expenses", "key1") == "val1"
+        assert get_table_property(test_catalog, "expenses", "key2") == "val2"
+
+    def test_set_nonexistent_table_raises(self, test_catalog):
+        """Test setting property on non-existent table raises."""
+        with pytest.raises(ValueError, match="not found"):
+            set_table_property(test_catalog, "nonexistent", "key", "val")
+
+    def test_set_different_tables(self, test_catalog):
+        """Test setting properties on different tables."""
+        set_table_property(test_catalog, "expenses", "key", "expenses_val")
+        set_table_property(test_catalog, "health", "key", "health_val")
+        assert get_table_property(test_catalog, "expenses", "key") == "expenses_val"
+        assert get_table_property(test_catalog, "health", "key") == "health_val"
+
+
+class TestRemoveTableProperty:
+    """Test remove_table_property function."""
+
+    def test_remove_property(self, test_catalog):
+        """Test removing a table property."""
+        set_table_property(test_catalog, "expenses", "custom.key", "value")
+        msg = remove_table_property(test_catalog, "expenses", "custom.key")
+        assert "Removed" in msg
+        assert get_table_property(test_catalog, "expenses", "custom.key") is None
+
+    def test_remove_nonexistent_property_raises(self, test_catalog):
+        """Test removing non-existent property raises."""
+        with pytest.raises(ValueError, match="not found"):
+            remove_table_property(test_catalog, "expenses", "nonexistent.key")
+
+    def test_remove_nonexistent_table_raises(self, test_catalog):
+        """Test removing property from non-existent table raises."""
+        with pytest.raises(ValueError, match="not found"):
+            remove_table_property(test_catalog, "nonexistent", "key")

--- a/uv.lock
+++ b/uv.lock
@@ -433,6 +433,7 @@ dependencies = [
     { name = "rich" },
     { name = "sqlalchemy" },
     { name = "tabulate" },
+    { name = "tomli-w" },
     { name = "vortex-data" },
 ]
 
@@ -453,6 +454,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "tabulate", specifier = ">=0.9.0" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "vortex-data", specifier = ">=0.50.0" },
 ]
 
@@ -1517,6 +1519,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds a TOML-based configuration system (`~/.lakehouse/config.toml`) supporting global default format and per-table overrides
- Implements format resolution chain: write-time override > Iceberg table property (`write.format.default`) > per-table config > global default > parquet
- Adds Iceberg table property management (`get/set/remove_table_property`) via PyIceberg transactions
- Adds CLI commands (`config show/set-format/get-format`, `alter TABLE set-property/get-property/remove-property`) and MCP tools (`get_format_config`, `set_format_config`, `set_table_property`)

Closes #16

## Changes
- **`config.py`** (new): TOML config read/write, format resolution logic
- **`catalog.py`**: Added `get_table_property`, `set_table_property`, `remove_table_property`
- **`cli.py`**: Added `config` command group and `alter` property subcommands
- **`server.py`**: Added 3 new MCP tools for format config and table properties
- **`tests/test_config.py`**: 23 tests for config management and format resolution
- **`tests/test_table_properties.py`**: 12 tests for Iceberg table property CRUD

## Test plan
- [x] All 157 tests pass (122 existing + 35 new)
- [ ] Verify `lakehouse config set-format vortex` persists to `~/.lakehouse/config.toml`
- [ ] Verify `lakehouse alter expenses set-property write.format.default vortex` works
- [ ] Test MCP tools via Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)