### PR TITLE
Add Vortex documentation and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Iceberg Lakehouse
 
-Local-first data lakehouse with Apache Iceberg storage and LLM access via MCP.
+Local-first data lakehouse with Apache Iceberg storage, Vortex columnar format, and LLM access via MCP.
 
 ## Architecture
 
@@ -13,24 +13,23 @@ Local-first data lakehouse with Apache Iceberg storage and LLM access via MCP.
                           ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                    MCP Server (lakehouse)                       │
-│  Tools: query, list_tables, describe_table, ingest             │
+│  Tools: query, insert, update, delete, upsert, convert, ...    │
 └─────────────────────────┬───────────────────────────────────────┘
                           │
                           ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                        DuckDB                                   │
-│              (in-memory, Iceberg extension)                     │
-└─────────────────────────┬───────────────────────────────────────┘
-                          │ iceberg_scan()
-                          ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    Iceberg Tables                               │
-│  ~/.lakehouse/warehouse/                                        │
-│  ├── expenses/     (financial data)                             │
-│  ├── health/       (health metrics)                             │
-│  ├── productivity/ (time tracking)                              │
-│  └── media/        (transcripts, notes)                         │
-└─────────────────────────────────────────────────────────────────┘
+│         (in-memory, Iceberg + Vortex extensions)                │
+└───────────────┬─────────────────────────┬───────────────────────┘
+                │ PyIceberg               │ Arrow bridge
+                ▼                         ▼
+┌──────────────────────────┐ ┌────────────────────────────────────┐
+│     Iceberg Tables       │ │        Vortex Files                │
+│  ~/.lakehouse/warehouse/ │ │   (exported .vortex files)         │
+│  ├── expenses/           │ │   Faster reads, smaller files      │
+│  ├── health/             │ └────────────────────────────────────┘
+│  └── notes/              │
+└──────────────────────────┘
 ```
 
 ## Quick Start
@@ -40,15 +39,100 @@ Local-first data lakehouse with Apache Iceberg storage and LLM access via MCP.
 cd iceberg-lakehouse
 uv sync
 
-# Initialize lakehouse (creates catalog + sample data)
-uv run lakehouse init
+# Initialize lakehouse (creates catalog + sample tables)
+uv run lakehouse init --with-sample-data
+
+# Query via CLI
+uv run lakehouse query "SELECT * FROM expenses LIMIT 10"
 
 # Start MCP server (for Claude Desktop)
 uv run lakehouse serve
-
-# Or query directly via CLI
-uv run lakehouse query "SELECT * FROM expenses LIMIT 10"
 ```
+
+## Features
+
+- **Iceberg Storage**: Full table versioning, time travel, schema evolution
+- **Vortex Format**: Columnar format with 37-76% smaller files and 1.3-2.8x faster reads
+- **DuckDB Queries**: Fast analytical queries with SQL
+- **LLM Access**: Natural language queries via MCP (18 tools)
+- **Local-First**: All data stays on your machine
+- **Full CRUD**: Insert, update, delete, upsert, batch operations
+- **Time Travel**: Query any historical snapshot of your data
+- **Schema Evolution**: Add, drop, rename columns without rewriting data
+- **Format Conversion**: Convert between Parquet and Vortex formats
+- **Configurable Formats**: Global and per-table format preferences
+
+## CLI Commands
+
+```bash
+# Data operations
+lakehouse query "SELECT * FROM expenses WHERE amount > 100"
+lakehouse query "SELECT * FROM expenses" --as-of 2025-12-01T00:00:00 --table-name expenses
+lakehouse ingest data.csv expenses --format csv
+
+# Table management
+lakehouse tables                          # List all tables
+lakehouse describe expenses               # Show table schema
+lakehouse snapshots expenses              # List snapshots
+lakehouse rollback expenses --snapshot-id 12345
+lakehouse expire expenses --retain-last 5
+
+# Schema evolution
+lakehouse alter expenses add-column tags string
+lakehouse alter expenses drop-column tags
+lakehouse alter expenses rename-column desc description
+
+# Batch operations
+lakehouse batch '[{"action":"insert","table_name":"expenses","rows":[{"id":10,"amount":50}]}]'
+lakehouse upsert expenses id '[{"id":1,"amount":90}]'
+lakehouse delete expenses "id = 5" --force
+
+# Vortex format
+lakehouse convert data.parquet --to vortex
+lakehouse convert data.vortex --to parquet
+lakehouse convert-table expenses -o ./exports --compact
+lakehouse query-vortex data.vortex "SELECT * FROM data"
+
+# Configuration
+lakehouse config show
+lakehouse config set-format vortex
+lakehouse config set-format parquet --table expenses
+lakehouse alter expenses set-property write.format.default vortex
+
+# Table properties
+lakehouse alter expenses set-property write.format.default vortex
+lakehouse alter expenses get-property write.format.default
+lakehouse alter expenses remove-property write.format.default
+
+# Benchmarks
+lakehouse benchmark --rows 1000,10000,100000
+lakehouse benchmark -o docs/benchmarks.md
+```
+
+## MCP Tools
+
+The MCP server exposes 18 tools for LLM access:
+
+| Tool | Description |
+|------|-------------|
+| `query` | Execute SQL queries (with time travel support) |
+| `list_tables` | List available tables |
+| `describe_table` | Get table schema |
+| `insert` | Insert rows |
+| `update` | Update rows matching a filter |
+| `delete` | Delete rows matching a filter |
+| `upsert` | Insert or update on key match |
+| `alter_table` | Add, drop, rename columns |
+| `batch` | Execute multiple operations |
+| `rollback` | Rollback to a previous snapshot |
+| `expire_snapshots` | Clean up old snapshots |
+| `list_snapshots` | List available snapshots |
+| `refresh` | Refresh table data |
+| `convert_format` | Export table to Vortex |
+| `query_vortex` | Query a Vortex file directly |
+| `get_format_config` | Get format configuration |
+| `set_format_config` | Set format preferences |
+| `set_table_property` | Set Iceberg table properties |
 
 ## Claude Desktop Configuration
 
@@ -59,10 +143,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "lakehouse": {
       "command": "uv",
-      "args": ["--directory", "/path/to/iceberg-lakehouse", "run", "lakehouse", "serve"],
-      "env": {
-        "LAKEHOUSE_PATH": "~/.lakehouse"
-      }
+      "args": ["--directory", "/path/to/iceberg-lakehouse", "run", "lakehouse", "serve"]
     }
   }
 }
@@ -72,29 +153,40 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```
 iceberg-lakehouse/
-├── pyproject.toml           # Dependencies (uv)
-├── src/
-│   └── lakehouse/
-│       ├── __init__.py
-│       ├── cli.py           # CLI commands
-│       ├── server.py        # MCP server
-│       ├── catalog.py       # Iceberg catalog management
-│       ├── query.py         # DuckDB query execution
-│       └── ingest.py        # Data ingestion utilities
-├── tests/
-└── README.md
+├── pyproject.toml              # Dependencies (uv)
+├── src/lakehouse/
+│   ├── __init__.py
+│   ├── cli.py                  # CLI commands (Click)
+│   ├── server.py               # MCP server (18 tools)
+│   ├── catalog.py              # Iceberg catalog + CRUD operations
+│   ├── query.py                # DuckDB query engine + Vortex integration
+│   ├── config.py               # Format configuration (TOML)
+│   ├── vortex_io.py            # Vortex I/O and conversion utilities
+│   └── _vortex_compat.py       # Substrait compatibility shim
+├── benchmarks/
+│   └── format_comparison.py    # Parquet vs Vortex benchmarks
+├── docs/
+│   ├── vortex.md               # Vortex format guide
+│   ├── format-comparison.md    # When to use Parquet vs Vortex
+│   ├── migration.md            # Data migration guide
+│   ├── benchmarks.md           # Benchmark results
+│   └── vortex-research.md      # Vortex research notes
+├── examples/
+│   ├── vortex_basic.py         # Basic Vortex usage
+│   ├── migrate_to_vortex.py    # Migration example
+│   └── mixed_format.py         # Mixed format queries
+└── tests/                      # 172 tests
 ```
 
-## Features
+## Documentation
 
-- **Iceberg Storage**: Full table versioning, time travel, schema evolution
-- **DuckDB Queries**: Fast analytical queries with SQL
-- **LLM Access**: Natural language queries via MCP
-- **Local-First**: All data stays on your machine
-- **PyIceberg Writes**: Full CRUD operations via Python
+- [Vortex Format Guide](docs/vortex.md) — How to use Vortex with the lakehouse
+- [Format Comparison](docs/format-comparison.md) — When to use Parquet vs Vortex
+- [Migration Guide](docs/migration.md) — Converting existing data
+- [Benchmark Results](docs/benchmarks.md) — Performance comparison
 
 ## Roadmap
 
-- [ ] Phase 1: Basic MCP server + Iceberg reads
-- [ ] Phase 2: Write support via PyIceberg
-- [ ] Phase 3: Vortex data format integration (when stable)
+- [x] Phase 1: Basic MCP server + Iceberg reads
+- [x] Phase 2: Write support (insert, update, delete, upsert, batch, schema evolution, time travel, snapshots)
+- [x] Phase 3: Vortex data format integration

--- a/docs/format-comparison.md
+++ b/docs/format-comparison.md
@@ -1,0 +1,107 @@
+# Parquet vs Vortex: When to Use Each Format
+
+## Quick Decision Guide
+
+| Use Case | Recommended Format |
+|----------|-------------------|
+| Default / general purpose | Parquet |
+| Read-heavy analytics | Vortex |
+| Frequent small writes | Parquet |
+| Large batch exports | Vortex |
+| Interoperability with other tools | Parquet |
+| Minimizing storage | Vortex |
+| String-heavy data | Vortex |
+
+## Performance Summary
+
+Based on benchmarks run on Apple Silicon (see [benchmarks.md](benchmarks.md)):
+
+### File Size
+
+Vortex produces significantly smaller files at scale:
+
+| Data Type | 1K Rows | 10K Rows |
+|-----------|---------|----------|
+| Numeric | 0.74x | 0.52x |
+| String | 0.87x | 0.76x |
+| Mixed | 0.79x | 0.37x |
+
+*Values < 1.0 mean Vortex is smaller. At very small scales (< 100 rows), Vortex has higher fixed overhead.*
+
+### Read Speed
+
+Vortex reads faster across all data types:
+
+| Data Type | 10K Rows Speedup |
+|-----------|-----------------|
+| Numeric | 1.9x faster |
+| String | 2.9x faster |
+| Mixed | 1.9x faster |
+
+### Write Speed
+
+Parquet writes faster, especially for small datasets:
+
+| Data Type | 10K Rows Speedup |
+|-----------|-----------------|
+| Numeric | 0.89x (Parquet ~10% faster) |
+| String | 0.26x (Parquet ~4x faster) |
+| Mixed | 0.33x (Parquet ~3x faster) |
+
+### DuckDB Query Performance
+
+Query performance is comparable. Parquet has a slight edge because DuckDB has a native Parquet reader, while Vortex goes through the Arrow bridge:
+
+- Simple queries: ~equivalent
+- Aggregations: Parquet slightly faster
+- Filtered scans: ~equivalent
+
+## Recommendations
+
+### Use Parquet When
+
+- **You're starting out**: Parquet is the default and most widely supported format
+- **Frequent writes**: Ingesting data frequently (Parquet write overhead is lower)
+- **Interoperability**: Other tools (Spark, Trino, Athena) need to read your data
+- **Small datasets**: Below ~1000 rows, Parquet's fixed overhead is smaller
+
+### Use Vortex When
+
+- **Read-heavy workloads**: Your data is written once and read many times
+- **Storage is a concern**: Vortex files are 37-76% smaller at scale
+- **String-heavy data**: Vortex excels at compressing text columns
+- **Batch exports**: Exporting large datasets for archival or sharing
+- **Analytics snapshots**: Creating point-in-time exports for analysis
+
+### Hybrid Approach
+
+The lakehouse supports using both formats simultaneously:
+
+1. Keep Iceberg tables in Parquet (for write performance and compatibility)
+2. Export read-heavy datasets to Vortex (for query performance and storage)
+3. Query both formats seamlessly via DuckDB
+
+```bash
+# Iceberg table stays in Parquet
+lakehouse query "SELECT * FROM expenses"
+
+# Export a snapshot to Vortex for fast analytics
+lakehouse convert-table expenses -o ./analytics --compact
+
+# Query the Vortex export
+lakehouse query-vortex ./analytics/expenses.vortex "SELECT category, sum(amount) FROM data GROUP BY category"
+```
+
+## Technical Details
+
+### Why Vortex is Smaller
+
+Vortex uses adaptive encoding that selects the best compression strategy per column. For mixed and string data, this often produces better results than Parquet's row-group-level compression.
+
+### Why Parquet Writes Faster
+
+Parquet's writer is highly optimized and has lower fixed overhead. Vortex's adaptive encoding requires more analysis during writes, which adds latency (especially for small datasets).
+
+### Why Read Performance Differs
+
+Vortex's columnar layout and encoding are optimized for sequential reads. The format's metadata structure allows efficient column projection and predicate evaluation.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,166 @@
+# Migration Guide: Converting Data Between Formats
+
+## Converting Iceberg Tables to Vortex
+
+Export an Iceberg table's current data to a Vortex file:
+
+```bash
+# Basic export
+lakehouse convert-table expenses
+
+# Export to a specific directory
+lakehouse convert-table expenses -o ./exports
+
+# Compact mode (smaller file, slower write)
+lakehouse convert-table expenses -o ./exports --compact
+```
+
+The Iceberg table itself remains unchanged (still in Parquet). This creates a separate `.vortex` file with the current snapshot's data.
+
+### Python API
+
+```python
+from lakehouse.catalog import get_catalog
+from lakehouse.vortex_io import convert_table_to_vortex
+
+catalog = get_catalog()
+result = convert_table_to_vortex(catalog, "expenses", "./exports")
+# result: {"table": "default.expenses", "output": "./exports/expenses.vortex",
+#          "rows": 1000, "size_bytes": 12345}
+```
+
+## Converting Between File Formats
+
+### Parquet to Vortex
+
+```bash
+lakehouse convert data.parquet --to vortex
+lakehouse convert data.parquet --to vortex -o output.vortex --compact
+```
+
+```python
+from lakehouse.vortex_io import convert_parquet_to_vortex
+
+result = convert_parquet_to_vortex("data.parquet")
+# result: {"input": "data.parquet", "output": "data.vortex",
+#          "rows": 1000, "input_size": 50000, "output_size": 30000}
+```
+
+### Vortex to Parquet
+
+```bash
+lakehouse convert data.vortex --to parquet
+lakehouse convert data.vortex --to parquet -o output.parquet
+```
+
+```python
+from lakehouse.vortex_io import convert_vortex_to_parquet
+
+result = convert_vortex_to_parquet("data.vortex")
+# result: {"input": "data.vortex", "output": "data.parquet",
+#          "rows": 1000, "input_size": 30000, "output_size": 50000}
+```
+
+## Setting Default Format for New Data
+
+### Global Default
+
+Set the default format for all tables:
+
+```bash
+lakehouse config set-format vortex
+```
+
+This writes to `~/.lakehouse/config.toml`:
+
+```toml
+[defaults]
+file_format = "vortex"
+```
+
+### Per-Table Format
+
+Override the format for specific tables:
+
+```bash
+lakehouse config set-format parquet --table expenses
+lakehouse config set-format vortex --table metrics
+```
+
+Config file:
+
+```toml
+[defaults]
+file_format = "parquet"
+
+[tables.metrics]
+file_format = "vortex"
+```
+
+### Iceberg Table Properties
+
+Set the format via Iceberg metadata (persisted with the table):
+
+```bash
+lakehouse alter expenses set-property write.format.default vortex
+```
+
+## Migration Workflow
+
+### Step 1: Benchmark Your Data
+
+Run benchmarks with your actual data sizes to see if Vortex is beneficial:
+
+```bash
+lakehouse benchmark --rows 1000,10000,100000
+```
+
+### Step 2: Export Test Data
+
+Export a single table to Vortex and compare:
+
+```bash
+# Export to Vortex
+lakehouse convert-table expenses -o ./test_export
+
+# Query both formats
+lakehouse query "SELECT count(*), sum(amount) FROM expenses"
+lakehouse query-vortex ./test_export/expenses.vortex "SELECT count(*), sum(amount) FROM data"
+```
+
+### Step 3: Configure Format Preferences
+
+If Vortex is beneficial for your workload:
+
+```bash
+# Set globally (all new data)
+lakehouse config set-format vortex
+
+# Or per-table (selective)
+lakehouse config set-format vortex --table metrics
+lakehouse config set-format vortex --table logs
+```
+
+### Step 4: Export Existing Tables
+
+Export tables that would benefit from Vortex:
+
+```bash
+lakehouse convert-table metrics -o ./vortex_data --compact
+lakehouse convert-table logs -o ./vortex_data --compact
+```
+
+## Data Integrity
+
+All conversions preserve data integrity:
+
+- Column names, types, and order are preserved
+- Null values are preserved
+- No data loss during Parquet ↔ Vortex roundtrips
+- Verified by roundtrip tests in the test suite
+
+## Limitations
+
+- **Iceberg native Vortex**: PyIceberg does not yet support Vortex as a native storage format. Tables are stored in Parquet; Vortex is used for exports.
+- **Schema metadata**: Some Iceberg-specific metadata (partition specs, sort orders) is not included in Vortex exports.
+- **Incremental export**: Each export is a full snapshot. Incremental exports are not yet supported.

--- a/docs/vortex.md
+++ b/docs/vortex.md
@@ -1,0 +1,173 @@
+# Vortex Format Guide
+
+Vortex is a columnar file format by SpiralDB (now under Linux Foundation LFAI&Data) designed for fast analytical reads with smaller file sizes than Parquet.
+
+## How Vortex Works in the Lakehouse
+
+The lakehouse uses Apache Iceberg as its primary table format (with Parquet as the default storage format). Vortex integrates as an alternative storage format:
+
+- **Iceberg tables** store data in Parquet (default) or can be exported to Vortex
+- **Vortex files** can be queried directly via DuckDB using the Arrow bridge
+- **Format conversion** between Parquet and Vortex is supported in both directions
+
+## Reading and Writing Vortex Files
+
+### Python API
+
+```python
+import pyarrow as pa
+from lakehouse.vortex_io import write_vortex, read_vortex
+
+# Write an Arrow table to Vortex
+table = pa.table({"id": [1, 2, 3], "name": ["a", "b", "c"]})
+result = write_vortex(table, "data.vortex")
+# result: {"path": "data.vortex", "rows": 3, "size_bytes": 1234}
+
+# Compact mode (smaller files, slower writes)
+write_vortex(table, "data_compact.vortex", compact=True)
+
+# Read a Vortex file back to Arrow
+table = read_vortex("data.vortex")
+```
+
+### CLI
+
+```bash
+# Convert Parquet to Vortex
+lakehouse convert data.parquet --to vortex
+
+# Convert with compact mode
+lakehouse convert data.parquet --to vortex --compact -o output.vortex
+
+# Convert Vortex back to Parquet
+lakehouse convert data.vortex --to parquet
+
+# Export an Iceberg table to Vortex
+lakehouse convert-table expenses -o ./exports
+```
+
+## Querying Vortex Files
+
+### Via CLI
+
+```bash
+# Query a Vortex file directly
+lakehouse query-vortex data.vortex "SELECT * FROM data WHERE amount > 100"
+
+# Custom table name in SQL
+lakehouse query-vortex data.vortex "SELECT * FROM expenses" --table-name expenses
+
+# Output formats
+lakehouse query-vortex data.vortex "SELECT count(*) FROM data" --format json
+```
+
+### Via Python
+
+```python
+from lakehouse.query import QueryEngine
+
+engine = QueryEngine()
+
+# Query a Vortex file directly
+df = engine.query_vortex("SELECT * FROM data", "data.vortex")
+
+# Register a Vortex file as a table for multiple queries
+engine.register_vortex("metrics", "metrics.vortex")
+df = engine.execute("SELECT * FROM metrics WHERE value > 100")
+```
+
+### Via MCP (LLM)
+
+The `query_vortex` MCP tool lets Claude query Vortex files:
+
+```
+"Query the metrics.vortex file for the top 10 values"
+→ Uses query_vortex tool with sql="SELECT * FROM data ORDER BY value DESC LIMIT 10"
+```
+
+## DuckDB Vortex Extension
+
+The lakehouse automatically detects and uses the DuckDB Vortex extension when available. This provides native read support without going through the Arrow bridge.
+
+```python
+engine = QueryEngine()
+
+# Check if the native extension is available
+if engine.has_vortex:
+    print("Native DuckDB Vortex extension loaded")
+else:
+    print("Using Arrow bridge fallback")
+```
+
+When the native extension is available:
+- `register_vortex()` creates a DuckDB view using `read_vortex()`
+- Queries can push down predicates directly to the Vortex reader
+
+When using the Arrow bridge fallback:
+- Vortex files are read into Arrow tables via `vortex-data`
+- Arrow tables are registered with DuckDB via `conn.register()`
+
+## Format Configuration
+
+### Global Default
+
+```bash
+# Set Vortex as the default format
+lakehouse config set-format vortex
+
+# Check current default
+lakehouse config get-format
+```
+
+### Per-Table Override
+
+```bash
+# Set format for a specific table
+lakehouse config set-format parquet --table expenses
+
+# View all configuration
+lakehouse config show
+```
+
+### Iceberg Table Properties
+
+```bash
+# Set format via Iceberg table properties
+lakehouse alter expenses set-property write.format.default vortex
+
+# Check the property
+lakehouse alter expenses get-property write.format.default
+```
+
+### Resolution Order
+
+When determining which format to use, the lakehouse checks (in order):
+
+1. **Write-time override** — explicit format passed to the operation
+2. **Iceberg table property** — `write.format.default` on the table
+3. **Per-table config** — `[tables.NAME]` section in config.toml
+4. **Global default** — `[defaults]` section in config.toml
+5. **Hardcoded fallback** — `parquet`
+
+## In-Memory Conversion
+
+For programmatic use without file I/O:
+
+```python
+from lakehouse.vortex_io import arrow_to_vortex, vortex_to_arrow
+
+# Arrow → Vortex (in-memory)
+vx_array = arrow_to_vortex(arrow_table)
+
+# Vortex → Arrow (in-memory)
+arrow_table = vortex_to_arrow(vx_array)
+```
+
+## File Metadata
+
+```python
+from lakehouse.vortex_io import vortex_file_info
+
+info = vortex_file_info("data.vortex")
+# {"path": "data.vortex", "size_bytes": 1234, "dtype": "..."}
+```

--- a/examples/migrate_to_vortex.py
+++ b/examples/migrate_to_vortex.py
@@ -1,0 +1,74 @@
+"""Migrating data from Parquet to Vortex format.
+
+Demonstrates converting files and Iceberg tables to Vortex.
+
+Usage:
+    uv run python examples/migrate_to_vortex.py
+"""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+from lakehouse.vortex_io import (
+    convert_parquet_to_vortex,
+    convert_vortex_to_parquet,
+    read_vortex,
+)
+
+output_dir = Path("./example_output")
+output_dir.mkdir(exist_ok=True)
+
+# Step 1: Create a sample Parquet file
+print("=== Step 1: Create sample Parquet file ===")
+data = pa.table({
+    "id": pa.array(range(1000), type=pa.int64()),
+    "category": pa.array(
+        ["groceries", "transport", "dining", "utilities", "entertainment"] * 200,
+        type=pa.string(),
+    ),
+    "amount": pa.array([float(i) * 1.5 + 10 for i in range(1000)], type=pa.float64()),
+    "currency": pa.array(["USD", "EUR", "GBP", "JPY"] * 250, type=pa.string()),
+})
+
+parquet_path = output_dir / "expenses.parquet"
+pq.write_table(data, str(parquet_path))
+print(f"Created {parquet_path} ({parquet_path.stat().st_size:,} bytes, {data.num_rows} rows)")
+
+# Step 2: Convert to Vortex
+print("\n=== Step 2: Convert Parquet → Vortex ===")
+result = convert_parquet_to_vortex(parquet_path, output_dir / "expenses.vortex")
+print(f"Input:  {result['input_size']:,} bytes")
+print(f"Output: {result['output_size']:,} bytes")
+ratio = result['output_size'] / result['input_size']
+print(f"Ratio:  {ratio:.2f}x ({(1 - ratio) * 100:.0f}% smaller)")
+
+# Step 3: Verify data integrity
+print("\n=== Step 3: Verify data integrity ===")
+original = pq.read_table(str(parquet_path))
+converted = read_vortex(output_dir / "expenses.vortex")
+assert original.num_rows == converted.num_rows
+assert original.column("id").to_pylist() == converted.column("id").to_pylist()
+print(f"Rows match: {original.num_rows} == {converted.num_rows}")
+print("Data integrity verified!")
+
+# Step 4: Convert with compact mode
+print("\n=== Step 4: Compact conversion ===")
+result_compact = convert_parquet_to_vortex(
+    parquet_path, output_dir / "expenses_compact.vortex", compact=True
+)
+print(f"Standard: {result['output_size']:,} bytes")
+print(f"Compact:  {result_compact['output_size']:,} bytes")
+
+# Step 5: Roundtrip (Parquet → Vortex → Parquet)
+print("\n=== Step 5: Full roundtrip ===")
+final_result = convert_vortex_to_parquet(
+    output_dir / "expenses.vortex",
+    output_dir / "expenses_roundtrip.parquet",
+)
+final = pq.read_table(str(output_dir / "expenses_roundtrip.parquet"))
+assert final.num_rows == original.num_rows
+assert final.column("amount").to_pylist() == original.column("amount").to_pylist()
+print(f"Roundtrip verified: {final.num_rows} rows, data intact")
+
+print("\nMigration complete! Files in ./example_output/")

--- a/examples/mixed_format.py
+++ b/examples/mixed_format.py
@@ -1,0 +1,102 @@
+"""Querying data across Parquet and Vortex formats.
+
+Demonstrates registering tables from different formats and joining them
+in a single DuckDB query.
+
+Usage:
+    uv run python examples/mixed_format.py
+"""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pathlib import Path
+
+from lakehouse.vortex_io import write_vortex
+from lakehouse.query import QueryEngine
+
+output_dir = Path("./example_output")
+output_dir.mkdir(exist_ok=True)
+
+# Create sample data in different formats
+print("=== Creating sample data ===")
+
+# Expenses in Parquet (frequent writes)
+expenses = pa.table({
+    "id": pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+    "category": pa.array(
+        ["groceries", "transport", "dining", "utilities", "groceries"],
+        type=pa.string(),
+    ),
+    "amount": pa.array([85.50, 24.00, 45.00, 120.00, 35.00], type=pa.float64()),
+})
+expenses_path = output_dir / "expenses.parquet"
+pq.write_table(expenses, str(expenses_path))
+print(f"Expenses (Parquet): {expenses.num_rows} rows")
+
+# Category budgets in Vortex (read-heavy reference data)
+budgets = pa.table({
+    "category": pa.array(
+        ["groceries", "transport", "dining", "utilities", "entertainment"],
+        type=pa.string(),
+    ),
+    "monthly_budget": pa.array([400.0, 150.0, 200.0, 200.0, 100.0], type=pa.float64()),
+})
+budgets_path = output_dir / "budgets.vortex"
+write_vortex(budgets, budgets_path)
+print(f"Budgets (Vortex): {budgets.num_rows} rows")
+
+# Query across both formats
+print("\n=== Mixed-format queries ===")
+
+engine = QueryEngine()
+
+# Register the Vortex file
+engine.register_vortex("budgets", budgets_path)
+
+# Register the Parquet file via DuckDB
+conn = engine._get_connection()
+conn.execute(f"CREATE VIEW expenses AS SELECT * FROM read_parquet('{expenses_path}')")
+
+# Join query across formats
+print("\n--- Spending vs Budget by Category ---")
+df = engine.execute("""
+    SELECT
+        e.category,
+        sum(e.amount) as total_spent,
+        b.monthly_budget,
+        round(sum(e.amount) / b.monthly_budget * 100, 1) as pct_used
+    FROM expenses e
+    JOIN budgets b ON e.category = b.category
+    GROUP BY e.category, b.monthly_budget
+    ORDER BY pct_used DESC
+""")
+print(df.to_string(index=False))
+
+# Aggregation query
+print("\n--- Summary ---")
+df = engine.execute("""
+    SELECT
+        count(*) as transactions,
+        round(sum(e.amount), 2) as total_spent,
+        round(sum(b.monthly_budget), 2) as total_budget
+    FROM expenses e
+    JOIN budgets b ON e.category = b.category
+""")
+print(df.to_string(index=False))
+
+# Categories over budget
+print("\n--- Over Budget ---")
+df = engine.execute("""
+    SELECT e.category, sum(e.amount) as spent, b.monthly_budget
+    FROM expenses e
+    JOIN budgets b ON e.category = b.category
+    GROUP BY e.category, b.monthly_budget
+    HAVING sum(e.amount) > b.monthly_budget * 0.5
+    ORDER BY spent DESC
+""")
+if df.empty:
+    print("No categories over 50% of budget")
+else:
+    print(df.to_string(index=False))
+
+print("\nDone! Mixed-format queries work seamlessly.")

--- a/examples/vortex_basic.py
+++ b/examples/vortex_basic.py
@@ -1,0 +1,61 @@
+"""Basic Vortex file operations.
+
+Demonstrates reading, writing, and querying Vortex files.
+
+Usage:
+    uv run python examples/vortex_basic.py
+"""
+
+import pyarrow as pa
+from pathlib import Path
+from lakehouse.vortex_io import write_vortex, read_vortex, vortex_file_info
+from lakehouse.query import QueryEngine
+
+# Create sample data
+data = pa.table({
+    "id": pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+    "name": pa.array(["Alice", "Bob", "Charlie", "Diana", "Eve"], type=pa.string()),
+    "score": pa.array([95.5, 87.3, 92.1, 78.9, 88.4], type=pa.float64()),
+})
+
+output_dir = Path("./example_output")
+output_dir.mkdir(exist_ok=True)
+
+# Write to Vortex
+print("=== Writing Vortex file ===")
+result = write_vortex(data, output_dir / "scores.vortex")
+print(f"Wrote {result['rows']} rows ({result['size_bytes']} bytes)")
+
+# Write in compact mode
+result_compact = write_vortex(data, output_dir / "scores_compact.vortex", compact=True)
+print(f"Compact: {result_compact['size_bytes']} bytes")
+
+# Read back
+print("\n=== Reading Vortex file ===")
+table = read_vortex(output_dir / "scores.vortex")
+print(f"Read {table.num_rows} rows, {table.num_columns} columns")
+print(f"Columns: {table.column_names}")
+
+# File info
+print("\n=== File info ===")
+info = vortex_file_info(output_dir / "scores.vortex")
+print(f"Size: {info['size_bytes']} bytes")
+print(f"DType: {info['dtype']}")
+
+# Query via DuckDB
+print("\n=== DuckDB queries ===")
+engine = QueryEngine()
+df = engine.query_vortex(
+    "SELECT name, score FROM data WHERE score > 90 ORDER BY score DESC",
+    output_dir / "scores.vortex",
+)
+print("Students with score > 90:")
+print(df.to_string(index=False))
+
+# Register and query
+print("\n=== Register and query ===")
+engine.register_vortex("students", output_dir / "scores.vortex")
+df = engine.execute("SELECT count(*) as total, avg(score) as avg_score FROM students")
+print(f"Total: {df['total'].iloc[0]}, Average: {df['avg_score'].iloc[0]:.1f}")
+
+print("\nDone! Files written to ./example_output/")


### PR DESCRIPTION
## Summary
- Rewrites README.md with complete feature list, all CLI commands, MCP tools table, updated architecture diagram, and project structure
- Adds 3 documentation guides: Vortex format guide, Parquet vs Vortex comparison, and data migration instructions
- Adds 3 runnable example scripts demonstrating basic usage, format migration, and mixed-format queries

Closes #19

## New Files
- **`docs/vortex.md`**: Complete Vortex format guide — reading, writing, querying (CLI/Python/MCP), DuckDB extension detection, format configuration, and in-memory conversion
- **`docs/format-comparison.md`**: Decision guide with benchmark-backed recommendations for when to use Parquet vs Vortex, including a hybrid approach
- **`docs/migration.md`**: Step-by-step migration workflow — benchmarking, test export, configuration, and batch conversion
- **`examples/vortex_basic.py`**: Read/write/query demo (verified working)
- **`examples/migrate_to_vortex.py`**: Parquet→Vortex conversion with integrity checks and roundtrip (verified working)
- **`examples/mixed_format.py`**: Cross-format DuckDB joins between Parquet and Vortex files (verified working)

## Updated Files
- **`README.md`**: Full rewrite — architecture diagram with Vortex, complete CLI reference, 18 MCP tools table, documentation links, updated roadmap

## Test plan
- [x] All 172 tests pass
- [x] All 3 example scripts run successfully
- [ ] Review documentation for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)