### PR TITLE
Implement data validation rules (#51)

### DIFF
--- a/src/lakehouse/validation.py
+++ b/src/lakehouse/validation.py
@@ -1,0 +1,300 @@
+"""Data validation rules for lakehouse tables."""
+
+import datetime
+import json
+import re
+import uuid
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_VALIDATION_PATH = Path.home() / ".lakehouse" / "validation.json"
+
+
+class ValidationError(Exception):
+    """Raised when data fails validation."""
+
+    def __init__(self, failures: list[dict]):
+        self.failures = failures
+        messages = [f["message"] for f in failures]
+        super().__init__(f"Validation failed: {'; '.join(messages)}")
+
+
+def _load_rules(store_path: Optional[Path] = None) -> dict:
+    """Load validation rules from disk."""
+    path = store_path or DEFAULT_VALIDATION_PATH
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, KeyError):
+        return {}
+
+
+def _save_rules(data: dict, store_path: Optional[Path] = None) -> None:
+    """Save validation rules to disk."""
+    path = store_path or DEFAULT_VALIDATION_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+
+
+def add_validation_rule(
+    table_name: str,
+    rule: dict,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Add a validation rule to a table.
+
+    Args:
+        table_name: Table name
+        rule: Rule dict with 'type' and type-specific fields
+
+    Returns:
+        Dict with rule details including generated ID
+    """
+    rule_type = rule.get("type")
+    valid_types = {"not_null", "unique", "range", "regex", "expression"}
+    if rule_type not in valid_types:
+        raise ValueError(f"Invalid rule type '{rule_type}'. Must be one of: {', '.join(sorted(valid_types))}")
+
+    # Validate rule-specific fields
+    if rule_type == "not_null":
+        if not rule.get("column"):
+            raise ValueError("not_null rule requires 'column'")
+    elif rule_type == "unique":
+        cols = rule.get("columns")
+        if not cols or not isinstance(cols, list):
+            raise ValueError("unique rule requires 'columns' (list)")
+    elif rule_type == "range":
+        if not rule.get("column"):
+            raise ValueError("range rule requires 'column'")
+        if "min" not in rule and "max" not in rule:
+            raise ValueError("range rule requires at least 'min' or 'max'")
+    elif rule_type == "regex":
+        if not rule.get("column"):
+            raise ValueError("regex rule requires 'column'")
+        if not rule.get("pattern"):
+            raise ValueError("regex rule requires 'pattern'")
+        # Validate pattern compiles
+        try:
+            re.compile(rule["pattern"])
+        except re.error as e:
+            raise ValueError(f"Invalid regex pattern: {e}")
+    elif rule_type == "expression":
+        if not rule.get("sql"):
+            raise ValueError("expression rule requires 'sql'")
+
+    rule_id = uuid.uuid4().hex[:8]
+    stored_rule = {
+        "id": rule_id,
+        **rule,
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+
+    store = _load_rules(store_path)
+    store.setdefault(table_name, []).append(stored_rule)
+    _save_rules(store, store_path)
+
+    return {
+        **stored_rule,
+        "message": f"Added {rule_type} rule '{rule_id}' to {table_name}",
+    }
+
+
+def list_validation_rules(
+    table_name: str,
+    store_path: Optional[Path] = None,
+) -> list[dict]:
+    """List all validation rules for a table."""
+    store = _load_rules(store_path)
+    return store.get(table_name, [])
+
+
+def remove_validation_rule(
+    table_name: str,
+    rule_id: str,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Remove a validation rule by ID."""
+    store = _load_rules(store_path)
+    rules = store.get(table_name, [])
+
+    for i, rule in enumerate(rules):
+        if rule["id"] == rule_id:
+            removed = rules.pop(i)
+            if not rules:
+                del store[table_name]
+            _save_rules(store, store_path)
+            return {
+                "id": rule_id,
+                "type": removed["type"],
+                "message": f"Removed rule '{rule_id}' from {table_name}",
+            }
+
+    raise ValueError(f"Rule '{rule_id}' not found for table '{table_name}'")
+
+
+def validate_rows(
+    rows: list[dict],
+    rules: list[dict],
+    existing_data: Optional[list[dict]] = None,
+) -> dict:
+    """Validate rows against a list of rules.
+
+    Args:
+        rows: Rows to validate
+        rules: Validation rules to check
+        existing_data: Existing table rows (needed for unique checks)
+
+    Returns:
+        Dict with 'valid' bool, 'failures' list, and 'checked' count
+    """
+    if not rules:
+        return {"valid": True, "failures": [], "checked": len(rows)}
+
+    failures = []
+
+    for rule in rules:
+        rule_type = rule["type"]
+
+        if rule_type == "not_null":
+            col = rule["column"]
+            for i, row in enumerate(rows):
+                val = row.get(col)
+                if val is None:
+                    failures.append({
+                        "rule_id": rule["id"],
+                        "rule_type": "not_null",
+                        "row_index": i,
+                        "column": col,
+                        "message": f"Column '{col}' must not be null (row {i})",
+                    })
+
+        elif rule_type == "range":
+            col = rule["column"]
+            min_val = rule.get("min")
+            max_val = rule.get("max")
+            for i, row in enumerate(rows):
+                val = row.get(col)
+                if val is None:
+                    continue
+                try:
+                    num_val = float(val)
+                except (TypeError, ValueError):
+                    continue
+                if min_val is not None and num_val < float(min_val):
+                    failures.append({
+                        "rule_id": rule["id"],
+                        "rule_type": "range",
+                        "row_index": i,
+                        "column": col,
+                        "message": f"Column '{col}' value {num_val} is below minimum {min_val} (row {i})",
+                    })
+                if max_val is not None and num_val > float(max_val):
+                    failures.append({
+                        "rule_id": rule["id"],
+                        "rule_type": "range",
+                        "row_index": i,
+                        "column": col,
+                        "message": f"Column '{col}' value {num_val} is above maximum {max_val} (row {i})",
+                    })
+
+        elif rule_type == "regex":
+            col = rule["column"]
+            pattern = re.compile(rule["pattern"])
+            for i, row in enumerate(rows):
+                val = row.get(col)
+                if val is None:
+                    continue
+                if not pattern.match(str(val)):
+                    failures.append({
+                        "rule_id": rule["id"],
+                        "rule_type": "regex",
+                        "row_index": i,
+                        "column": col,
+                        "message": f"Column '{col}' value '{val}' does not match pattern '{rule['pattern']}' (row {i})",
+                    })
+
+        elif rule_type == "expression":
+            import duckdb
+            sql_expr = rule["sql"]
+            conn = duckdb.connect()
+            try:
+                conn.register("candidate", _rows_to_duckdb(rows))
+                failing = conn.execute(
+                    f"SELECT rowid FROM (SELECT row_number() OVER () - 1 AS rowid, * FROM candidate) WHERE NOT ({sql_expr})"
+                ).fetchall()
+                for (row_idx,) in failing:
+                    failures.append({
+                        "rule_id": rule["id"],
+                        "rule_type": "expression",
+                        "row_index": int(row_idx),
+                        "message": f"Row {int(row_idx)} failed expression: {sql_expr}",
+                    })
+            except Exception as e:
+                failures.append({
+                    "rule_id": rule["id"],
+                    "rule_type": "expression",
+                    "row_index": -1,
+                    "message": f"Expression rule error: {e}",
+                })
+            finally:
+                conn.close()
+
+        elif rule_type == "unique":
+            cols = rule["columns"]
+            # Check within the new rows
+            seen = {}
+            for i, row in enumerate(rows):
+                key = tuple(row.get(c) for c in cols)
+                if key in seen:
+                    failures.append({
+                        "rule_id": rule["id"],
+                        "rule_type": "unique",
+                        "row_index": i,
+                        "columns": cols,
+                        "message": f"Duplicate value for columns {cols} at row {i} (same as row {seen[key]})",
+                    })
+                else:
+                    seen[key] = i
+
+            # Check against existing data
+            if existing_data:
+                existing_keys = {tuple(row.get(c) for c in cols) for row in existing_data}
+                for i, row in enumerate(rows):
+                    key = tuple(row.get(c) for c in cols)
+                    if key in existing_keys:
+                        failures.append({
+                            "rule_id": rule["id"],
+                            "rule_type": "unique",
+                            "row_index": i,
+                            "columns": cols,
+                            "message": f"Value for columns {cols} at row {i} already exists in table",
+                        })
+
+    return {
+        "valid": len(failures) == 0,
+        "failures": failures,
+        "checked": len(rows),
+    }
+
+
+def _rows_to_duckdb(rows: list[dict]):
+    """Convert row dicts to a format DuckDB can consume."""
+    import pyarrow as pa
+
+    if not rows:
+        return pa.table({})
+
+    # Collect all columns
+    columns = {}
+    for row in rows:
+        for k, v in row.items():
+            if k not in columns:
+                columns[k] = []
+
+    for row in rows:
+        for k in columns:
+            columns[k].append(row.get(k))
+
+    return pa.table(columns)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,386 @@
+"""Tests for data validation rules."""
+
+import json
+import pytest
+from pathlib import Path
+
+from lakehouse.validation import (
+    add_validation_rule,
+    list_validation_rules,
+    remove_validation_rule,
+    validate_rows,
+    ValidationError,
+    _load_rules,
+)
+from lakehouse.catalog import (
+    create_table,
+    insert_rows,
+    update_rows,
+    upsert_rows,
+)
+
+
+@pytest.fixture
+def rules_path(tmp_path):
+    """Return a temporary validation rules path."""
+    return tmp_path / "validation.json"
+
+
+@pytest.fixture
+def validated_table(test_catalog, rules_path):
+    """Create a table and return (catalog, table_name, rules_path)."""
+    create_table(test_catalog, "validated", {"id": "long", "name": "string", "amount": "double"})
+    return test_catalog, "validated", rules_path
+
+
+# --- Rule CRUD ---
+
+class TestAddRule:
+    """Test adding validation rules."""
+
+    def test_add_not_null(self, rules_path):
+        result = add_validation_rule("expenses", {"type": "not_null", "column": "id"}, store_path=rules_path)
+        assert result["type"] == "not_null"
+        assert result["column"] == "id"
+        assert "id" in result
+        assert "Added" in result["message"]
+
+    def test_add_unique(self, rules_path):
+        result = add_validation_rule("expenses", {"type": "unique", "columns": ["id"]}, store_path=rules_path)
+        assert result["type"] == "unique"
+        assert result["columns"] == ["id"]
+
+    def test_add_range(self, rules_path):
+        result = add_validation_rule("expenses", {"type": "range", "column": "amount", "min": 0, "max": 10000}, store_path=rules_path)
+        assert result["type"] == "range"
+        assert result["min"] == 0
+        assert result["max"] == 10000
+
+    def test_add_regex(self, rules_path):
+        result = add_validation_rule("expenses", {"type": "regex", "column": "email", "pattern": "^[^@]+@[^@]+$"}, store_path=rules_path)
+        assert result["type"] == "regex"
+
+    def test_add_expression(self, rules_path):
+        result = add_validation_rule("expenses", {"type": "expression", "sql": "amount > 0"}, store_path=rules_path)
+        assert result["type"] == "expression"
+
+    def test_add_persists(self, rules_path):
+        add_validation_rule("expenses", {"type": "not_null", "column": "id"}, store_path=rules_path)
+        data = json.loads(rules_path.read_text())
+        assert "expenses" in data
+        assert len(data["expenses"]) == 1
+
+    def test_add_multiple(self, rules_path):
+        add_validation_rule("expenses", {"type": "not_null", "column": "id"}, store_path=rules_path)
+        add_validation_rule("expenses", {"type": "range", "column": "amount", "min": 0}, store_path=rules_path)
+        rules = list_validation_rules("expenses", store_path=rules_path)
+        assert len(rules) == 2
+
+    def test_add_invalid_type(self, rules_path):
+        with pytest.raises(ValueError, match="Invalid rule type"):
+            add_validation_rule("expenses", {"type": "invalid"}, store_path=rules_path)
+
+    def test_add_not_null_missing_column(self, rules_path):
+        with pytest.raises(ValueError, match="requires 'column'"):
+            add_validation_rule("expenses", {"type": "not_null"}, store_path=rules_path)
+
+    def test_add_range_missing_bounds(self, rules_path):
+        with pytest.raises(ValueError, match="requires at least"):
+            add_validation_rule("expenses", {"type": "range", "column": "amount"}, store_path=rules_path)
+
+    def test_add_regex_invalid_pattern(self, rules_path):
+        with pytest.raises(ValueError, match="Invalid regex"):
+            add_validation_rule("expenses", {"type": "regex", "column": "name", "pattern": "[invalid"}, store_path=rules_path)
+
+
+class TestListRules:
+    """Test listing rules."""
+
+    def test_list_empty(self, rules_path):
+        rules = list_validation_rules("expenses", store_path=rules_path)
+        assert rules == []
+
+    def test_list_returns_all(self, rules_path):
+        add_validation_rule("expenses", {"type": "not_null", "column": "id"}, store_path=rules_path)
+        add_validation_rule("expenses", {"type": "not_null", "column": "name"}, store_path=rules_path)
+        rules = list_validation_rules("expenses", store_path=rules_path)
+        assert len(rules) == 2
+
+    def test_list_different_tables(self, rules_path):
+        add_validation_rule("expenses", {"type": "not_null", "column": "id"}, store_path=rules_path)
+        add_validation_rule("health", {"type": "not_null", "column": "metric"}, store_path=rules_path)
+        assert len(list_validation_rules("expenses", store_path=rules_path)) == 1
+        assert len(list_validation_rules("health", store_path=rules_path)) == 1
+
+
+class TestRemoveRule:
+    """Test removing rules."""
+
+    def test_remove_existing(self, rules_path):
+        result = add_validation_rule("expenses", {"type": "not_null", "column": "id"}, store_path=rules_path)
+        rule_id = result["id"]
+
+        removed = remove_validation_rule("expenses", rule_id, store_path=rules_path)
+        assert removed["id"] == rule_id
+        assert "Removed" in removed["message"]
+
+        assert list_validation_rules("expenses", store_path=rules_path) == []
+
+    def test_remove_nonexistent(self, rules_path):
+        with pytest.raises(ValueError, match="not found"):
+            remove_validation_rule("expenses", "nonexistent", store_path=rules_path)
+
+    def test_remove_one_keeps_others(self, rules_path):
+        r1 = add_validation_rule("expenses", {"type": "not_null", "column": "id"}, store_path=rules_path)
+        add_validation_rule("expenses", {"type": "not_null", "column": "name"}, store_path=rules_path)
+
+        remove_validation_rule("expenses", r1["id"], store_path=rules_path)
+        rules = list_validation_rules("expenses", store_path=rules_path)
+        assert len(rules) == 1
+        assert rules[0]["column"] == "name"
+
+
+# --- Validation logic ---
+
+class TestValidateNotNull:
+    """Test not_null validation."""
+
+    def test_passes(self):
+        rules = [{"id": "r1", "type": "not_null", "column": "id"}]
+        result = validate_rows([{"id": 1}, {"id": 2}], rules)
+        assert result["valid"]
+
+    def test_fails(self):
+        rules = [{"id": "r1", "type": "not_null", "column": "id"}]
+        result = validate_rows([{"id": 1}, {"id": None}], rules)
+        assert not result["valid"]
+        assert len(result["failures"]) == 1
+        assert result["failures"][0]["row_index"] == 1
+
+    def test_missing_key_is_null(self):
+        rules = [{"id": "r1", "type": "not_null", "column": "id"}]
+        result = validate_rows([{"name": "test"}], rules)
+        assert not result["valid"]
+
+
+class TestValidateRange:
+    """Test range validation."""
+
+    def test_in_range(self):
+        rules = [{"id": "r1", "type": "range", "column": "amount", "min": 0, "max": 100}]
+        result = validate_rows([{"amount": 50}], rules)
+        assert result["valid"]
+
+    def test_below_min(self):
+        rules = [{"id": "r1", "type": "range", "column": "amount", "min": 0, "max": 100}]
+        result = validate_rows([{"amount": -5}], rules)
+        assert not result["valid"]
+
+    def test_above_max(self):
+        rules = [{"id": "r1", "type": "range", "column": "amount", "min": 0, "max": 100}]
+        result = validate_rows([{"amount": 150}], rules)
+        assert not result["valid"]
+
+    def test_null_passes(self):
+        """Null values pass range checks (not_null should catch those)."""
+        rules = [{"id": "r1", "type": "range", "column": "amount", "min": 0}]
+        result = validate_rows([{"amount": None}], rules)
+        assert result["valid"]
+
+    def test_min_only(self):
+        rules = [{"id": "r1", "type": "range", "column": "amount", "min": 0}]
+        result = validate_rows([{"amount": 50}], rules)
+        assert result["valid"]
+
+
+class TestValidateRegex:
+    """Test regex validation."""
+
+    def test_matches(self):
+        rules = [{"id": "r1", "type": "regex", "column": "category", "pattern": "^[a-z_]+$"}]
+        result = validate_rows([{"category": "food_and_drink"}], rules)
+        assert result["valid"]
+
+    def test_no_match(self):
+        rules = [{"id": "r1", "type": "regex", "column": "category", "pattern": "^[a-z_]+$"}]
+        result = validate_rows([{"category": "INVALID"}], rules)
+        assert not result["valid"]
+
+    def test_null_passes(self):
+        rules = [{"id": "r1", "type": "regex", "column": "category", "pattern": "^[a-z]+$"}]
+        result = validate_rows([{"category": None}], rules)
+        assert result["valid"]
+
+
+class TestValidateExpression:
+    """Test expression validation."""
+
+    def test_passes(self):
+        rules = [{"id": "r1", "type": "expression", "sql": "amount > 0"}]
+        result = validate_rows([{"amount": 10}, {"amount": 20}], rules)
+        assert result["valid"]
+
+    def test_fails(self):
+        rules = [{"id": "r1", "type": "expression", "sql": "amount > 0"}]
+        result = validate_rows([{"amount": 10}, {"amount": -5}], rules)
+        assert not result["valid"]
+        assert len(result["failures"]) == 1
+
+
+class TestValidateUnique:
+    """Test unique validation."""
+
+    def test_unique_within_batch(self):
+        rules = [{"id": "r1", "type": "unique", "columns": ["id"]}]
+        result = validate_rows([{"id": 1}, {"id": 2}], rules)
+        assert result["valid"]
+
+    def test_duplicate_within_batch(self):
+        rules = [{"id": "r1", "type": "unique", "columns": ["id"]}]
+        result = validate_rows([{"id": 1}, {"id": 1}], rules)
+        assert not result["valid"]
+
+    def test_duplicate_against_existing(self):
+        rules = [{"id": "r1", "type": "unique", "columns": ["id"]}]
+        existing = [{"id": 1}, {"id": 2}]
+        result = validate_rows([{"id": 1}], rules, existing_data=existing)
+        assert not result["valid"]
+
+    def test_unique_against_existing(self):
+        rules = [{"id": "r1", "type": "unique", "columns": ["id"]}]
+        existing = [{"id": 1}, {"id": 2}]
+        result = validate_rows([{"id": 3}], rules, existing_data=existing)
+        assert result["valid"]
+
+
+class TestValidateMultipleRules:
+    """Test multiple rules on same data."""
+
+    def test_all_pass(self):
+        rules = [
+            {"id": "r1", "type": "not_null", "column": "id"},
+            {"id": "r2", "type": "range", "column": "amount", "min": 0},
+        ]
+        result = validate_rows([{"id": 1, "amount": 50}], rules)
+        assert result["valid"]
+
+    def test_multiple_failures(self):
+        rules = [
+            {"id": "r1", "type": "not_null", "column": "id"},
+            {"id": "r2", "type": "range", "column": "amount", "min": 0},
+        ]
+        result = validate_rows([{"id": None, "amount": -5}], rules)
+        assert not result["valid"]
+        assert len(result["failures"]) == 2
+
+
+class TestValidateEmpty:
+    """Test validation with no rules."""
+
+    def test_no_rules_passes(self):
+        result = validate_rows([{"id": 1}], [])
+        assert result["valid"]
+
+    def test_empty_rows_passes(self):
+        rules = [{"id": "r1", "type": "not_null", "column": "id"}]
+        result = validate_rows([], rules)
+        assert result["valid"]
+
+
+# --- Integration with write operations ---
+
+class TestInsertValidation:
+    """Test validation on insert."""
+
+    def test_insert_valid_data(self, validated_table, rules_path):
+        catalog, table, rp = validated_table
+        add_validation_rule(f"default.{table}", {"type": "not_null", "column": "id"}, store_path=rp)
+
+        # Patch the default path for integration
+        import lakehouse.validation as val_mod
+        original = val_mod.DEFAULT_VALIDATION_PATH
+        val_mod.DEFAULT_VALIDATION_PATH = rp
+        try:
+            count = insert_rows(catalog, table, [{"id": 1, "name": "test", "amount": 10.0}])
+            assert count == 1
+        finally:
+            val_mod.DEFAULT_VALIDATION_PATH = original
+
+    def test_insert_invalid_data_raises(self, validated_table, rules_path):
+        catalog, table, rp = validated_table
+        add_validation_rule(f"default.{table}", {"type": "not_null", "column": "id"}, store_path=rp)
+
+        import lakehouse.validation as val_mod
+        original = val_mod.DEFAULT_VALIDATION_PATH
+        val_mod.DEFAULT_VALIDATION_PATH = rp
+        try:
+            with pytest.raises(ValidationError):
+                insert_rows(catalog, table, [{"id": None, "name": "test", "amount": 10.0}])
+        finally:
+            val_mod.DEFAULT_VALIDATION_PATH = original
+
+    def test_insert_range_violation(self, validated_table, rules_path):
+        catalog, table, rp = validated_table
+        add_validation_rule(f"default.{table}", {"type": "range", "column": "amount", "min": 0}, store_path=rp)
+
+        import lakehouse.validation as val_mod
+        original = val_mod.DEFAULT_VALIDATION_PATH
+        val_mod.DEFAULT_VALIDATION_PATH = rp
+        try:
+            with pytest.raises(ValidationError):
+                insert_rows(catalog, table, [{"id": 1, "name": "test", "amount": -5.0}])
+        finally:
+            val_mod.DEFAULT_VALIDATION_PATH = original
+
+
+class TestUpdateValidation:
+    """Test validation on update."""
+
+    def test_update_valid_data(self, validated_table, rules_path):
+        catalog, table, rp = validated_table
+        insert_rows(catalog, table, [{"id": 1, "name": "test", "amount": 10.0}])
+
+        add_validation_rule(f"default.{table}", {"type": "range", "column": "amount", "min": 0}, store_path=rp)
+
+        import lakehouse.validation as val_mod
+        original = val_mod.DEFAULT_VALIDATION_PATH
+        val_mod.DEFAULT_VALIDATION_PATH = rp
+        try:
+            count = update_rows(catalog, table, "id = 1", {"amount": 20.0})
+            assert count == 1
+        finally:
+            val_mod.DEFAULT_VALIDATION_PATH = original
+
+    def test_update_invalid_data_raises(self, validated_table, rules_path):
+        catalog, table, rp = validated_table
+        insert_rows(catalog, table, [{"id": 1, "name": "test", "amount": 10.0}])
+
+        add_validation_rule(f"default.{table}", {"type": "range", "column": "amount", "min": 0}, store_path=rp)
+
+        import lakehouse.validation as val_mod
+        original = val_mod.DEFAULT_VALIDATION_PATH
+        val_mod.DEFAULT_VALIDATION_PATH = rp
+        try:
+            with pytest.raises(ValidationError):
+                update_rows(catalog, table, "id = 1", {"amount": -50.0})
+        finally:
+            val_mod.DEFAULT_VALIDATION_PATH = original
+
+
+class TestStoreResilience:
+    """Test edge cases."""
+
+    def test_load_nonexistent(self, rules_path):
+        data = _load_rules(rules_path)
+        assert data == {}
+
+    def test_load_corrupt_json(self, rules_path):
+        rules_path.parent.mkdir(parents=True, exist_ok=True)
+        rules_path.write_text("not json{{{")
+        data = _load_rules(rules_path)
+        assert data == {}
+
+    def test_creates_parent_dirs(self, rules_path):
+        nested = rules_path.parent / "deep" / "nested" / "validation.json"
+        add_validation_rule("expenses", {"type": "not_null", "column": "id"}, store_path=nested)
+        assert nested.exists()


### PR DESCRIPTION
## Summary

- Adds `validation.py` module with rule CRUD: `add_validation_rule`, `list_validation_rules`, `remove_validation_rule`, `validate_rows`
- Supports 5 rule types: `not_null`, `unique`, `range`, `regex`, `expression` (SQL predicates via DuckDB)
- Rules stored in `~/.lakehouse/validation.json` with auto-generated UUIDs
- Integrates with `insert_rows()`, `update_rows()`, and `upsert_rows()` — invalid data raises `ValidationError` before write
- Adds `lakehouse validate <table>` CLI subcommand group with `add`, `list`, `remove`, `check` commands
- Adds 4 MCP tools: `add_validation_rule`, `list_validation_rules`, `remove_validation_rule`, `validate_data`
- 46 new tests across 14 test classes

## Test plan

- [x] All 46 new tests pass
- [x] Full suite of 416 tests pass
- [ ] Manual test: `lakehouse validate expenses add not_null --column id`
- [ ] Manual test: `lakehouse validate expenses list`
- [ ] Manual test: `lakehouse validate expenses check '[{"id": null}]'`

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)