### PR TITLE
Implement audit log (#52)

### DIFF
--- a/src/lakehouse/audit.py
+++ b/src/lakehouse/audit.py
@@ -1,0 +1,183 @@
+"""Audit log for tracking all write operations."""
+
+import datetime
+import json
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_AUDIT_PATH = Path.home() / ".lakehouse" / "audit.log"
+MAX_AUDIT_ENTRIES = 10000
+
+
+def log_operation(
+    table_name: str,
+    operation: str,
+    rows_affected: int = 0,
+    source: str = "api",
+    details: Optional[dict] = None,
+    store_path: Optional[Path] = None,
+) -> None:
+    """Append an audit entry.
+
+    Args:
+        table_name: Name of the table
+        operation: Operation type (insert, update, delete, etc.)
+        rows_affected: Number of rows affected
+        source: Source of operation (cli, mcp, api)
+        details: Additional operation-specific metadata
+        store_path: Optional path to audit log file
+    """
+    path = store_path or DEFAULT_AUDIT_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    entry = {
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "table": table_name,
+        "operation": operation,
+        "rows_affected": rows_affected,
+        "source": source,
+        "details": details or {},
+    }
+
+    with open(path, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+    # Enforce cap
+    _enforce_cap(path)
+
+
+def get_audit_log(
+    table_name: Optional[str] = None,
+    operation: Optional[str] = None,
+    limit: int = 50,
+    since: Optional[str] = None,
+    store_path: Optional[Path] = None,
+) -> list[dict]:
+    """Query the audit log with optional filters.
+
+    Args:
+        table_name: Filter by table name
+        operation: Filter by operation type
+        limit: Maximum entries to return
+        since: ISO timestamp — only entries after this time
+        store_path: Optional path to audit log file
+
+    Returns:
+        List of audit entries (most recent first)
+    """
+    path = store_path or DEFAULT_AUDIT_PATH
+    if not path.exists():
+        return []
+
+    entries = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        if table_name and entry.get("table") != table_name:
+            continue
+        if operation and entry.get("operation") != operation:
+            continue
+        if since:
+            entry_ts = entry.get("timestamp", "")
+            if entry_ts < since:
+                continue
+
+        entries.append(entry)
+
+    # Most recent first
+    entries.reverse()
+    return entries[:limit]
+
+
+def clear_audit_log(
+    older_than: Optional[str] = None,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Clear audit entries.
+
+    Args:
+        older_than: If provided, only clear entries older than this.
+                    Accepts ISO timestamp or duration like '30d', '24h'.
+        store_path: Optional path to audit log file
+
+    Returns:
+        Dict with cleared count and message
+    """
+    path = store_path or DEFAULT_AUDIT_PATH
+    if not path.exists():
+        return {"cleared": 0, "message": "No audit log found"}
+
+    lines = path.read_text().splitlines()
+    if not lines:
+        return {"cleared": 0, "message": "Audit log is empty"}
+
+    if older_than is None:
+        count = len(lines)
+        path.write_text("")
+        return {"cleared": count, "message": f"Cleared all {count} audit entries"}
+
+    cutoff = _parse_older_than(older_than)
+    kept = []
+    cleared = 0
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            entry_ts = entry.get("timestamp", "")
+            if entry_ts < cutoff:
+                cleared += 1
+            else:
+                kept.append(line)
+        except json.JSONDecodeError:
+            kept.append(line)
+
+    path.write_text("\n".join(kept) + "\n" if kept else "")
+    return {"cleared": cleared, "remaining": len(kept), "message": f"Cleared {cleared} entries older than {older_than}"}
+
+
+def _parse_older_than(value: str) -> str:
+    """Parse an older_than value to an ISO timestamp string.
+
+    Accepts ISO timestamp or duration strings like '30d', '24h', '7d'.
+    """
+    # Try as ISO timestamp first
+    try:
+        datetime.datetime.fromisoformat(value)
+        return value
+    except (ValueError, TypeError):
+        pass
+
+    # Parse duration
+    now = datetime.datetime.now(datetime.timezone.utc)
+    value = value.strip().lower()
+
+    if value.endswith("d"):
+        days = int(value[:-1])
+        cutoff = now - datetime.timedelta(days=days)
+    elif value.endswith("h"):
+        hours = int(value[:-1])
+        cutoff = now - datetime.timedelta(hours=hours)
+    elif value.endswith("m"):
+        minutes = int(value[:-1])
+        cutoff = now - datetime.timedelta(minutes=minutes)
+    else:
+        raise ValueError(f"Invalid older_than format: '{value}'. Use ISO timestamp or duration (e.g., '30d', '24h')")
+
+    return cutoff.isoformat()
+
+
+def _enforce_cap(path: Path) -> None:
+    """Enforce max entries cap by removing oldest entries."""
+    lines = path.read_text().splitlines()
+    if len(lines) > MAX_AUDIT_ENTRIES:
+        # Keep only the most recent entries
+        path.write_text("\n".join(lines[-MAX_AUDIT_ENTRIES:]) + "\n")

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,318 @@
+"""Tests for audit log functionality."""
+
+import json
+import datetime
+import pytest
+from pathlib import Path
+
+from lakehouse.audit import (
+    log_operation,
+    get_audit_log,
+    clear_audit_log,
+    MAX_AUDIT_ENTRIES,
+)
+from lakehouse.catalog import (
+    insert_rows,
+    update_rows,
+    delete_rows,
+    create_table,
+)
+
+
+@pytest.fixture
+def audit_path(tmp_path):
+    """Return a temporary audit log path."""
+    return tmp_path / "audit.log"
+
+
+# --- Core logging ---
+
+class TestLogOperation:
+    """Test logging operations."""
+
+    def test_log_insert(self, audit_path):
+        log_operation("expenses", "insert", rows_affected=3, source="cli", store_path=audit_path)
+
+        entries = get_audit_log(store_path=audit_path)
+        assert len(entries) == 1
+        assert entries[0]["table"] == "expenses"
+        assert entries[0]["operation"] == "insert"
+        assert entries[0]["rows_affected"] == 3
+        assert entries[0]["source"] == "cli"
+
+    def test_log_update(self, audit_path):
+        log_operation("expenses", "update", rows_affected=1, details={"filter": "id = 5"}, store_path=audit_path)
+
+        entries = get_audit_log(store_path=audit_path)
+        assert entries[0]["operation"] == "update"
+        assert entries[0]["details"]["filter"] == "id = 5"
+
+    def test_log_delete(self, audit_path):
+        log_operation("expenses", "delete", rows_affected=2, store_path=audit_path)
+
+        entries = get_audit_log(store_path=audit_path)
+        assert entries[0]["operation"] == "delete"
+        assert entries[0]["rows_affected"] == 2
+
+    def test_log_includes_timestamp(self, audit_path):
+        log_operation("expenses", "insert", store_path=audit_path)
+
+        entries = get_audit_log(store_path=audit_path)
+        assert "timestamp" in entries[0]
+        # Should be ISO format
+        datetime.datetime.fromisoformat(entries[0]["timestamp"])
+
+    def test_log_multiple(self, audit_path):
+        log_operation("expenses", "insert", rows_affected=3, store_path=audit_path)
+        log_operation("expenses", "update", rows_affected=1, store_path=audit_path)
+        log_operation("health", "delete", rows_affected=5, store_path=audit_path)
+
+        entries = get_audit_log(store_path=audit_path)
+        assert len(entries) == 3
+
+    def test_log_default_source(self, audit_path):
+        log_operation("expenses", "insert", store_path=audit_path)
+
+        entries = get_audit_log(store_path=audit_path)
+        assert entries[0]["source"] == "api"
+
+    def test_jsonl_format(self, audit_path):
+        """Each entry is a valid JSON line."""
+        log_operation("expenses", "insert", rows_affected=1, store_path=audit_path)
+        log_operation("expenses", "update", rows_affected=2, store_path=audit_path)
+
+        lines = audit_path.read_text().strip().splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            entry = json.loads(line)
+            assert "timestamp" in entry
+            assert "table" in entry
+
+
+# --- Querying ---
+
+class TestGetAuditLog:
+    """Test querying the audit log."""
+
+    def test_empty_log(self, audit_path):
+        entries = get_audit_log(store_path=audit_path)
+        assert entries == []
+
+    def test_most_recent_first(self, audit_path):
+        log_operation("t", "insert", rows_affected=1, store_path=audit_path)
+        log_operation("t", "update", rows_affected=2, store_path=audit_path)
+        log_operation("t", "delete", rows_affected=3, store_path=audit_path)
+
+        entries = get_audit_log(store_path=audit_path)
+        assert entries[0]["operation"] == "delete"
+        assert entries[1]["operation"] == "update"
+        assert entries[2]["operation"] == "insert"
+
+    def test_filter_by_table(self, audit_path):
+        log_operation("expenses", "insert", store_path=audit_path)
+        log_operation("health", "insert", store_path=audit_path)
+        log_operation("expenses", "update", store_path=audit_path)
+
+        entries = get_audit_log(table_name="expenses", store_path=audit_path)
+        assert len(entries) == 2
+        assert all(e["table"] == "expenses" for e in entries)
+
+    def test_filter_by_operation(self, audit_path):
+        log_operation("expenses", "insert", store_path=audit_path)
+        log_operation("expenses", "update", store_path=audit_path)
+        log_operation("expenses", "insert", store_path=audit_path)
+
+        entries = get_audit_log(operation="insert", store_path=audit_path)
+        assert len(entries) == 2
+
+    def test_filter_by_since(self, audit_path):
+        # Log an entry with a past timestamp by writing directly
+        old_entry = {
+            "timestamp": "2020-01-01T00:00:00+00:00",
+            "table": "expenses",
+            "operation": "insert",
+            "rows_affected": 1,
+            "source": "api",
+            "details": {},
+        }
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(audit_path, "w") as f:
+            f.write(json.dumps(old_entry) + "\n")
+
+        log_operation("expenses", "update", store_path=audit_path)
+
+        entries = get_audit_log(since="2025-01-01", store_path=audit_path)
+        assert len(entries) == 1
+        assert entries[0]["operation"] == "update"
+
+    def test_combined_filters(self, audit_path):
+        log_operation("expenses", "insert", store_path=audit_path)
+        log_operation("expenses", "update", store_path=audit_path)
+        log_operation("health", "insert", store_path=audit_path)
+
+        entries = get_audit_log(table_name="expenses", operation="insert", store_path=audit_path)
+        assert len(entries) == 1
+
+    def test_limit(self, audit_path):
+        for i in range(10):
+            log_operation("t", "insert", rows_affected=i, store_path=audit_path)
+
+        entries = get_audit_log(limit=3, store_path=audit_path)
+        assert len(entries) == 3
+        # Most recent first
+        assert entries[0]["rows_affected"] == 9
+
+
+# --- Clearing ---
+
+class TestClearAuditLog:
+    """Test clearing audit entries."""
+
+    def test_clear_all(self, audit_path):
+        for i in range(5):
+            log_operation("t", "insert", store_path=audit_path)
+
+        result = clear_audit_log(store_path=audit_path)
+        assert result["cleared"] == 5
+
+        entries = get_audit_log(store_path=audit_path)
+        assert entries == []
+
+    def test_clear_empty(self, audit_path):
+        result = clear_audit_log(store_path=audit_path)
+        assert result["cleared"] == 0
+
+    def test_clear_older_than(self, audit_path):
+        # Write old and new entries
+        old = {
+            "timestamp": "2020-01-01T00:00:00+00:00",
+            "table": "t",
+            "operation": "insert",
+            "rows_affected": 1,
+            "source": "api",
+            "details": {},
+        }
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(audit_path, "w") as f:
+            f.write(json.dumps(old) + "\n")
+
+        log_operation("t", "update", store_path=audit_path)
+
+        result = clear_audit_log(older_than="2025-01-01T00:00:00+00:00", store_path=audit_path)
+        assert result["cleared"] == 1
+
+        entries = get_audit_log(store_path=audit_path)
+        assert len(entries) == 1
+        assert entries[0]["operation"] == "update"
+
+    def test_clear_with_duration(self, audit_path):
+        # Write an old entry
+        old = {
+            "timestamp": "2020-01-01T00:00:00+00:00",
+            "table": "t",
+            "operation": "old",
+            "rows_affected": 0,
+            "source": "api",
+            "details": {},
+        }
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(audit_path, "w") as f:
+            f.write(json.dumps(old) + "\n")
+
+        log_operation("t", "new", store_path=audit_path)
+
+        result = clear_audit_log(older_than="1d", store_path=audit_path)
+        assert result["cleared"] == 1
+
+        entries = get_audit_log(store_path=audit_path)
+        assert len(entries) == 1
+        assert entries[0]["operation"] == "new"
+
+
+# --- Cap enforcement ---
+
+class TestCapEnforcement:
+    """Test max entries cap."""
+
+    def test_cap_enforced(self, audit_path):
+        for i in range(MAX_AUDIT_ENTRIES + 50):
+            log_operation("t", "insert", rows_affected=i, store_path=audit_path)
+
+        lines = audit_path.read_text().strip().splitlines()
+        assert len(lines) == MAX_AUDIT_ENTRIES
+
+        # Most recent should be kept
+        last_entry = json.loads(lines[-1])
+        assert last_entry["rows_affected"] == MAX_AUDIT_ENTRIES + 49
+
+
+# --- Integration ---
+
+class TestInsertAuditIntegration:
+    """Test that insert_rows auto-logs to audit."""
+
+    def test_insert_logs_audit(self, test_catalog, audit_path):
+        import lakehouse.audit as audit_mod
+        original = audit_mod.DEFAULT_AUDIT_PATH
+        audit_mod.DEFAULT_AUDIT_PATH = audit_path
+        try:
+            create_table(test_catalog, "audit_test", {"id": "long", "val": "string"})
+            insert_rows(test_catalog, "audit_test", [{"id": 1, "val": "a"}, {"id": 2, "val": "b"}])
+
+            entries = get_audit_log(store_path=audit_path)
+            # Should have at least the insert entry
+            insert_entries = [e for e in entries if e["operation"] == "insert"]
+            assert len(insert_entries) >= 1
+            assert insert_entries[0]["rows_affected"] == 2
+        finally:
+            audit_mod.DEFAULT_AUDIT_PATH = original
+
+    def test_update_logs_audit(self, test_catalog, audit_path):
+        import lakehouse.audit as audit_mod
+        original = audit_mod.DEFAULT_AUDIT_PATH
+        audit_mod.DEFAULT_AUDIT_PATH = audit_path
+        try:
+            create_table(test_catalog, "audit_upd", {"id": "long", "val": "string"})
+            insert_rows(test_catalog, "audit_upd", [{"id": 1, "val": "a"}])
+            update_rows(test_catalog, "audit_upd", "id = 1", {"val": "b"})
+
+            entries = get_audit_log(operation="update", store_path=audit_path)
+            assert len(entries) >= 1
+            assert entries[0]["details"]["filter"] == "id = 1"
+        finally:
+            audit_mod.DEFAULT_AUDIT_PATH = original
+
+    def test_delete_logs_audit(self, test_catalog, audit_path):
+        import lakehouse.audit as audit_mod
+        original = audit_mod.DEFAULT_AUDIT_PATH
+        audit_mod.DEFAULT_AUDIT_PATH = audit_path
+        try:
+            create_table(test_catalog, "audit_del", {"id": "long", "val": "string"})
+            insert_rows(test_catalog, "audit_del", [{"id": 1, "val": "a"}])
+            delete_rows(test_catalog, "audit_del", "id = 1")
+
+            entries = get_audit_log(operation="delete", store_path=audit_path)
+            assert len(entries) >= 1
+            assert entries[0]["rows_affected"] == 1
+        finally:
+            audit_mod.DEFAULT_AUDIT_PATH = original
+
+
+# --- Edge cases ---
+
+class TestEdgeCases:
+    """Test edge cases."""
+
+    def test_creates_parent_dirs(self, audit_path):
+        nested = audit_path.parent / "deep" / "nested" / "audit.log"
+        log_operation("t", "insert", store_path=nested)
+        assert nested.exists()
+
+    def test_corrupt_lines_skipped(self, audit_path):
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(audit_path, "w") as f:
+            f.write("not valid json\n")
+            f.write(json.dumps({"timestamp": "2026-01-01", "table": "t", "operation": "insert", "rows_affected": 1, "source": "api", "details": {}}) + "\n")
+
+        entries = get_audit_log(store_path=audit_path)
+        assert len(entries) == 1


### PR DESCRIPTION
## Summary

- Adds `audit.py` module with JSONL append-only logging at `~/.lakehouse/audit.log`
- `log_operation()` records table, operation, rows_affected, source, details, and timestamp
- Auto-logging integrated into 8 write operations: `insert_rows`, `update_rows`, `delete_rows`, `upsert_rows`, `rollback_table`, `expire_snapshots`, `alter_table`, `compact_table`
- `get_audit_log()` with filters: table_name, operation, since, limit (most recent first)
- `clear_audit_log()` with optional `older_than` (ISO timestamp or duration like '30d')
- Cap at 10,000 entries with automatic pruning
- CLI `lakehouse audit` command with `--table`, `--operation`, `--since`, `--limit`, `--clear`, `--older-than`
- 2 MCP tools: `get_audit_log`, `clear_audit_log`
- 24 new tests across 7 test classes

## Test plan

- [x] All 24 new tests pass
- [x] Full suite of 440 tests pass
- [ ] Manual: `lakehouse audit`
- [ ] Manual: `lakehouse audit --table expenses --operation insert`

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)