### PR TITLE
Implement lakehouse dashboard (#54)

### DIFF
--- a/src/lakehouse/dashboard.py
+++ b/src/lakehouse/dashboard.py
@@ -1,0 +1,148 @@
+"""Lakehouse dashboard — comprehensive status overview."""
+
+from pathlib import Path
+from typing import Optional
+
+from pyiceberg.catalog import Catalog
+
+
+def _format_size(size_bytes: int) -> str:
+    """Format bytes into human-readable size."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    elif size_bytes < 1024 * 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    elif size_bytes < 1024 * 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    else:
+        return f"{size_bytes / (1024 * 1024 * 1024):.1f} GB"
+
+
+def _table_health(data_files: int, orphan_files: int, is_stale: bool) -> str:
+    """Determine health indicator for a table.
+
+    Returns one of: Good, Compact, Orphans, Stale
+    """
+    if is_stale:
+        return "Stale"
+    if orphan_files > 0:
+        return "Orphans"
+    if data_files >= 10:
+        return "Compact"
+    return "Good"
+
+
+def get_dashboard(
+    catalog: Catalog,
+    warehouse_path: Optional[Path] = None,
+    stats_store_path: Optional[Path] = None,
+    audit_store_path: Optional[Path] = None,
+    queries_store_path: Optional[Path] = None,
+) -> dict:
+    """Generate comprehensive lakehouse dashboard data.
+
+    Args:
+        catalog: The Iceberg catalog
+        warehouse_path: Path to warehouse directory
+        stats_store_path: Optional path to stats cache
+        audit_store_path: Optional path to audit log
+        queries_store_path: Optional path to queries store
+
+    Returns:
+        Dict with storage_path, namespaces, total_tables, total_size_bytes,
+        tables (list), recent_activity, saved_queries_count,
+        history_entries_count.
+    """
+    from .catalog import list_tables, list_namespaces, maintenance_status, DEFAULT_WAREHOUSE
+    from .stats import get_cached_stats, is_stats_stale
+    from .audit import get_audit_log
+    from .queries import list_saved_queries, get_history
+
+    storage_path = str(warehouse_path or DEFAULT_WAREHOUSE)
+
+    # Namespaces
+    namespaces = list_namespaces(catalog)
+
+    # All tables across namespaces
+    all_table_names = list_tables(catalog, namespace="*")
+
+    # Gather per-table info
+    tables = []
+    total_size = 0
+
+    for tbl_name in all_table_names:
+        # Try cached stats first for speed
+        cached = get_cached_stats(tbl_name, stats_store_path)
+        stale = is_stats_stale(tbl_name, catalog, stats_store_path)
+
+        if cached:
+            row_count = cached["row_count"]
+            size_bytes = cached["size_bytes"]
+            data_files = cached["data_files"]
+        else:
+            # Fall back to live scan
+            try:
+                maint = maintenance_status(catalog, tbl_name)
+                row_count = None  # maintenance_status doesn't include row count
+                size_bytes = maint["total_size_bytes"]
+                data_files = maint["data_files"]
+            except Exception:
+                row_count = None
+                size_bytes = 0
+                data_files = 0
+
+        # Get orphan info from maintenance
+        orphan_files = 0
+        try:
+            maint = maintenance_status(catalog, tbl_name)
+            orphan_files = maint.get("orphan_files", 0)
+            # If we didn't have cached stats, use maintenance data
+            if row_count is None:
+                data_files = maint["data_files"]
+                size_bytes = maint["total_size_bytes"]
+        except Exception:
+            pass
+
+        # If still no row count, try a quick scan
+        if row_count is None:
+            try:
+                table = catalog.load_table(tbl_name)
+                arrow_table = table.scan().to_arrow()
+                row_count = arrow_table.num_rows
+            except Exception:
+                row_count = 0
+
+        health = _table_health(data_files, orphan_files, stale)
+        total_size += size_bytes
+
+        tables.append({
+            "name": tbl_name,
+            "rows": row_count,
+            "size_bytes": size_bytes,
+            "size_display": _format_size(size_bytes),
+            "data_files": data_files,
+            "health": health,
+        })
+
+    # Recent activity from audit log
+    recent_activity = get_audit_log(limit=5, store_path=audit_store_path)
+
+    # Saved queries count
+    saved_queries = list_saved_queries(store_path=queries_store_path)
+    saved_queries_count = len(saved_queries)
+
+    # Query history count
+    history = get_history(limit=10000, store_path=queries_store_path)
+    history_entries_count = len(history)
+
+    return {
+        "storage_path": storage_path,
+        "namespaces": namespaces,
+        "total_tables": len(all_table_names),
+        "total_size_bytes": total_size,
+        "total_size_display": _format_size(total_size),
+        "tables": tables,
+        "recent_activity": recent_activity,
+        "saved_queries_count": saved_queries_count,
+        "history_entries_count": history_entries_count,
+    }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,262 @@
+"""Tests for lakehouse dashboard functionality."""
+
+import json
+import pytest
+from pathlib import Path
+
+from lakehouse.dashboard import get_dashboard, _format_size, _table_health
+from lakehouse.catalog import (
+    create_table,
+    insert_rows,
+    create_namespace,
+)
+from lakehouse.stats import compute_table_stats
+from lakehouse.audit import log_operation
+from lakehouse.queries import save_query
+
+
+@pytest.fixture
+def stats_path(tmp_path):
+    return tmp_path / "stats_cache.json"
+
+
+@pytest.fixture
+def audit_path(tmp_path):
+    return tmp_path / "audit.log"
+
+
+@pytest.fixture
+def queries_path(tmp_path):
+    return tmp_path / "queries.json"
+
+
+# --- Helpers ---
+
+
+class TestFormatSize:
+    def test_bytes(self):
+        assert _format_size(500) == "500 B"
+
+    def test_kilobytes(self):
+        assert _format_size(2048) == "2.0 KB"
+
+    def test_megabytes(self):
+        assert _format_size(1024 * 1024 * 3) == "3.0 MB"
+
+    def test_gigabytes(self):
+        assert _format_size(1024 * 1024 * 1024 * 2) == "2.0 GB"
+
+    def test_zero(self):
+        assert _format_size(0) == "0 B"
+
+
+class TestTableHealth:
+    def test_good(self):
+        assert _table_health(3, 0, False) == "Good"
+
+    def test_compact(self):
+        assert _table_health(15, 0, False) == "Compact"
+
+    def test_orphans(self):
+        assert _table_health(3, 2, False) == "Orphans"
+
+    def test_stale(self):
+        assert _table_health(3, 0, True) == "Stale"
+
+    def test_stale_takes_priority(self):
+        """Stale overrides compact and orphans."""
+        assert _table_health(15, 2, True) == "Stale"
+
+    def test_orphans_over_compact(self):
+        """Orphans checked before compact."""
+        assert _table_health(15, 2, False) == "Orphans"
+
+
+# --- Dashboard ---
+
+
+class TestDashboard:
+    def test_default_tables(self, test_catalog, stats_path, audit_path, queries_path):
+        """Dashboard works with default sample tables."""
+        data = get_dashboard(
+            test_catalog,
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        assert data["total_tables"] >= 1
+        assert "storage_path" in data
+        assert isinstance(data["namespaces"], list)
+        assert "default" in data["namespaces"]
+        assert isinstance(data["tables"], list)
+        assert data["total_size_bytes"] >= 0
+
+    def test_includes_table_info(self, test_catalog, stats_path, audit_path, queries_path):
+        """Each table entry has expected fields."""
+        create_table(test_catalog, "dash_test", columns={"id": "long", "val": "string"})
+        insert_rows(test_catalog, "default.dash_test", [{"id": 1, "val": "hello"}])
+
+        data = get_dashboard(
+            test_catalog,
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        table_entry = next(t for t in data["tables"] if t["name"] == "default.dash_test")
+        assert table_entry["rows"] == 1
+        assert "size_bytes" in table_entry
+        assert "size_display" in table_entry
+        assert "data_files" in table_entry
+        assert table_entry["health"] in ("Good", "Compact", "Orphans", "Stale")
+
+    def test_uses_cached_stats(self, test_catalog, stats_path, audit_path, queries_path):
+        """Dashboard uses cached stats when available."""
+        create_table(test_catalog, "cached_dash", columns={"id": "long"})
+        insert_rows(test_catalog, "default.cached_dash", [{"id": 1}, {"id": 2}])
+        compute_table_stats(test_catalog, "default.cached_dash", stats_path)
+
+        data = get_dashboard(
+            test_catalog,
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        table_entry = next(t for t in data["tables"] if t["name"] == "default.cached_dash")
+        assert table_entry["rows"] == 2
+
+    def test_health_good(self, test_catalog, stats_path, audit_path, queries_path):
+        """Table with few files shows Good health."""
+        create_table(test_catalog, "good_health", columns={"id": "long"})
+        insert_rows(test_catalog, "default.good_health", [{"id": 1}])
+        compute_table_stats(test_catalog, "default.good_health", stats_path)
+
+        data = get_dashboard(
+            test_catalog,
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        table_entry = next(t for t in data["tables"] if t["name"] == "default.good_health")
+        assert table_entry["health"] == "Good"
+
+    def test_health_stale(self, test_catalog, stats_path, audit_path, queries_path):
+        """Table with outdated cache shows Stale health."""
+        create_table(test_catalog, "stale_health", columns={"id": "long"})
+        insert_rows(test_catalog, "default.stale_health", [{"id": 1}])
+        compute_table_stats(test_catalog, "default.stale_health", stats_path)
+
+        # Insert more data to make cache stale
+        insert_rows(test_catalog, "default.stale_health", [{"id": 2}])
+
+        data = get_dashboard(
+            test_catalog,
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        table_entry = next(t for t in data["tables"] if t["name"] == "default.stale_health")
+        assert table_entry["health"] == "Stale"
+
+    def test_recent_activity(self, test_catalog, stats_path, audit_path, queries_path):
+        """Dashboard includes recent audit activity."""
+        log_operation("default.test", "insert", rows_affected=5, store_path=audit_path)
+        log_operation("default.test", "update", rows_affected=2, store_path=audit_path)
+
+        data = get_dashboard(
+            test_catalog,
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        assert len(data["recent_activity"]) == 2
+
+    def test_saved_queries_count(self, test_catalog, stats_path, audit_path, queries_path):
+        """Dashboard includes saved queries count."""
+        save_query("q1", "SELECT 1", store_path=queries_path)
+        save_query("q2", "SELECT 2", store_path=queries_path)
+
+        data = get_dashboard(
+            test_catalog,
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        assert data["saved_queries_count"] == 2
+
+    def test_history_entries_count(self, test_catalog, stats_path, audit_path, queries_path):
+        """Dashboard includes query history count."""
+        data = get_dashboard(
+            test_catalog,
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        assert data["history_entries_count"] >= 0
+
+    def test_json_output_format(self, test_catalog, stats_path, audit_path, queries_path):
+        """Dashboard output is JSON-serializable."""
+        data = get_dashboard(
+            test_catalog,
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        # Should not raise
+        serialized = json.dumps(data, default=str)
+        parsed = json.loads(serialized)
+        expected_keys = {
+            "storage_path", "namespaces", "total_tables", "total_size_bytes",
+            "total_size_display", "tables", "recent_activity",
+            "saved_queries_count", "history_entries_count",
+        }
+        assert expected_keys.issubset(set(parsed.keys()))
+
+    def test_namespace_list(self, test_catalog, stats_path, audit_path, queries_path):
+        """Dashboard includes namespace list."""
+        data = get_dashboard(
+            test_catalog,
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        assert "default" in data["namespaces"]
+
+    def test_multiple_namespaces(self, test_catalog, stats_path, audit_path, queries_path):
+        """Dashboard shows tables from multiple namespaces."""
+        create_namespace(test_catalog, "staging")
+        create_table(test_catalog, "staging.events", columns={"id": "long"})
+
+        data = get_dashboard(
+            test_catalog,
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        ns = data["namespaces"]
+        assert "default" in ns
+        assert "staging" in ns
+        table_names = [t["name"] for t in data["tables"]]
+        assert "staging.events" in table_names
+
+    def test_empty_lakehouse(self, tmp_path, stats_path, audit_path, queries_path):
+        """Dashboard handles empty lakehouse (no tables)."""
+        import uuid
+        from lakehouse.catalog import get_catalog, init_catalog
+
+        catalog = get_catalog(
+            warehouse_path=tmp_path / "wh",
+            catalog_db=tmp_path / "cat.db",
+            name=f"test_{uuid.uuid4().hex[:8]}",
+        )
+        init_catalog(catalog)
+
+        data = get_dashboard(
+            catalog,
+            warehouse_path=tmp_path / "wh",
+            stats_store_path=stats_path,
+            audit_store_path=audit_path,
+            queries_store_path=queries_path,
+        )
+        assert data["total_tables"] == 0
+        assert data["tables"] == []
+        assert data["total_size_bytes"] == 0


### PR DESCRIPTION
## Summary
- Add `src/lakehouse/dashboard.py` with `get_dashboard()` generating comprehensive status overview
- Aggregates data from tables, stats cache, audit log, saved queries, and namespaces
- Per-table health indicators: Good (<10 files), Compact (>=10 files), Orphans, Stale (outdated cache)
- CLI `dashboard` command with Rich table formatting and `--json` flag
- MCP `dashboard` tool with markdown-formatted output for LLM consumption
- 23 tests covering default tables, multiple namespaces, empty lakehouse, health indicators, recent activity, JSON output

## Test plan
- [x] All 23 new dashboard tests pass
- [x] Full suite of 496 tests passes
- [x] Verify dashboard shows correct table counts and sizes
- [x] Verify health indicators (Good, Stale) work correctly
- [x] Verify recent activity from audit log is included
- [x] Verify saved queries count is correct
- [x] Verify multiple namespaces are shown

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)