### PR TITLE
Implement data lineage tracking (#64)

### DIFF
--- a/src/lakehouse/lineage.py
+++ b/src/lakehouse/lineage.py
@@ -1,0 +1,285 @@
+"""Data lineage tracking — table-level dependency graph."""
+
+import datetime
+import json
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_LINEAGE_PATH = Path.home() / ".lakehouse" / "lineage.json"
+
+
+def _load_store(store_path: Optional[Path] = None) -> dict:
+    path = store_path or DEFAULT_LINEAGE_PATH
+    if not path.exists():
+        return {"edges": []}
+    try:
+        data = json.loads(path.read_text())
+        if "edges" not in data:
+            data["edges"] = []
+        return data
+    except (json.JSONDecodeError, KeyError):
+        return {"edges": []}
+
+
+def _save_store(data: dict, store_path: Optional[Path] = None) -> None:
+    path = store_path or DEFAULT_LINEAGE_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, default=str))
+
+
+def _normalize_name(table_name: str) -> str:
+    if "." not in table_name:
+        return f"default.{table_name}"
+    return table_name
+
+
+def record_lineage(
+    source_tables: list[str],
+    target_table: str,
+    operation: str = "manual",
+    sql: Optional[str] = None,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Record a lineage edge: source_tables → target_table.
+
+    Args:
+        source_tables: List of source table names
+        target_table: Target table name
+        operation: Operation type (insert_from, view, pipeline, manual)
+        sql: Optional SQL that produced this relationship
+
+    Returns:
+        Dict with lineage entry details.
+    """
+    if not source_tables:
+        raise ValueError("source_tables must not be empty")
+    if not target_table or not target_table.strip():
+        raise ValueError("target_table must not be empty")
+
+    sources = sorted(set(_normalize_name(s) for s in source_tables if s.strip()))
+    if not sources:
+        raise ValueError("source_tables must contain at least one non-empty name")
+    target = _normalize_name(target_table)
+
+    store = _load_store(store_path)
+
+    # Check for duplicate edge (same sources + target)
+    for edge in store["edges"]:
+        if sorted(edge["sources"]) == sources and edge["target"] == target:
+            # Update existing edge
+            edge["operation"] = operation
+            edge["sql"] = sql
+            edge["recorded_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+            _save_store(store, store_path)
+            return {
+                "sources": sources,
+                "target": target,
+                "operation": operation,
+                "sql": sql,
+                "recorded_at": edge["recorded_at"],
+                "message": f"Updated lineage: {sources} → {target}",
+            }
+
+    edge = {
+        "sources": sources,
+        "target": target,
+        "operation": operation,
+        "sql": sql,
+        "recorded_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    store["edges"].append(edge)
+    _save_store(store, store_path)
+
+    return {
+        "sources": sources,
+        "target": target,
+        "operation": operation,
+        "sql": sql,
+        "recorded_at": edge["recorded_at"],
+        "message": f"Recorded lineage: {sources} → {target}",
+    }
+
+
+def get_upstream(
+    table_name: str,
+    store_path: Optional[Path] = None,
+    transitive: bool = True,
+) -> list[dict]:
+    """Get all tables that feed into this table.
+
+    Args:
+        table_name: Table to find upstream dependencies for
+        transitive: If True, include indirect dependencies (default)
+
+    Returns:
+        List of dicts with source info and depth.
+    """
+    table_name = _normalize_name(table_name)
+    store = _load_store(store_path)
+
+    if not transitive:
+        results = []
+        for edge in store["edges"]:
+            if edge["target"] == table_name:
+                for src in edge["sources"]:
+                    results.append({
+                        "table": src,
+                        "operation": edge["operation"],
+                        "depth": 1,
+                    })
+        return sorted(results, key=lambda r: r["table"])
+
+    # BFS for transitive closure with cycle detection
+    visited = set()
+    queue = [(table_name, 0)]
+    results = []
+
+    while queue:
+        current, depth = queue.pop(0)
+        for edge in store["edges"]:
+            if edge["target"] == current:
+                for src in edge["sources"]:
+                    if src not in visited:
+                        visited.add(src)
+                        results.append({
+                            "table": src,
+                            "operation": edge["operation"],
+                            "depth": depth + 1,
+                        })
+                        queue.append((src, depth + 1))
+
+    return sorted(results, key=lambda r: (r["depth"], r["table"]))
+
+
+def get_downstream(
+    table_name: str,
+    store_path: Optional[Path] = None,
+    transitive: bool = True,
+) -> list[dict]:
+    """Get all tables that depend on this table.
+
+    Args:
+        table_name: Table to find downstream dependents for
+        transitive: If True, include indirect dependents (default)
+
+    Returns:
+        List of dicts with target info and depth.
+    """
+    table_name = _normalize_name(table_name)
+    store = _load_store(store_path)
+
+    if not transitive:
+        results = []
+        for edge in store["edges"]:
+            if table_name in edge["sources"]:
+                results.append({
+                    "table": edge["target"],
+                    "operation": edge["operation"],
+                    "depth": 1,
+                })
+        return sorted(results, key=lambda r: r["table"])
+
+    # BFS for transitive closure with cycle detection
+    visited = set()
+    queue = [(table_name, 0)]
+    results = []
+
+    while queue:
+        current, depth = queue.pop(0)
+        for edge in store["edges"]:
+            if current in edge["sources"]:
+                target = edge["target"]
+                if target not in visited:
+                    visited.add(target)
+                    results.append({
+                        "table": target,
+                        "operation": edge["operation"],
+                        "depth": depth + 1,
+                    })
+                    queue.append((target, depth + 1))
+
+    return sorted(results, key=lambda r: (r["depth"], r["table"]))
+
+
+def get_lineage_graph(
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Get the full lineage graph.
+
+    Returns:
+        Dict with nodes (set of all tables) and edges list.
+    """
+    store = _load_store(store_path)
+    nodes = set()
+    edges = []
+
+    for edge in store["edges"]:
+        for src in edge["sources"]:
+            nodes.add(src)
+        nodes.add(edge["target"])
+        edges.append({
+            "sources": edge["sources"],
+            "target": edge["target"],
+            "operation": edge["operation"],
+        })
+
+    return {
+        "nodes": sorted(nodes),
+        "edges": edges,
+        "node_count": len(nodes),
+        "edge_count": len(edges),
+    }
+
+
+def remove_lineage(
+    source_table: str,
+    target_table: str,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Remove a lineage edge between source and target.
+
+    Removes any edge where source_table is in the sources list
+    and the target matches target_table.
+    """
+    source = _normalize_name(source_table)
+    target = _normalize_name(target_table)
+    store = _load_store(store_path)
+
+    original_count = len(store["edges"])
+    store["edges"] = [
+        e for e in store["edges"]
+        if not (source in e["sources"] and e["target"] == target)
+    ]
+    removed = original_count - len(store["edges"])
+
+    _save_store(store, store_path)
+
+    if removed == 0:
+        return {"message": f"No lineage edge found from {source} to {target}", "removed": 0}
+    return {"message": f"Removed {removed} lineage edge(s) from {source} to {target}", "removed": removed}
+
+
+def get_impact_analysis(
+    table_name: str,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Analyze the impact of dropping or modifying a table.
+
+    Returns downstream dependencies and their depths.
+    """
+    table_name = _normalize_name(table_name)
+    downstream = get_downstream(table_name, store_path=store_path, transitive=True)
+
+    affected = [d["table"] for d in downstream]
+
+    return {
+        "table": table_name,
+        "affected_tables": affected,
+        "affected_count": len(affected),
+        "details": downstream,
+        "message": (
+            f"Dropping {table_name} would affect {len(affected)} table(s)"
+            if affected
+            else f"No downstream dependencies for {table_name}"
+        ),
+    }

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,0 +1,305 @@
+"""Tests for data lineage tracking."""
+
+import json
+import pytest
+from pathlib import Path
+
+from lakehouse.lineage import (
+    record_lineage,
+    get_upstream,
+    get_downstream,
+    get_lineage_graph,
+    remove_lineage,
+    get_impact_analysis,
+)
+
+
+@pytest.fixture
+def lineage_path(tmp_path):
+    """Return a temporary lineage store path."""
+    return tmp_path / "lineage.json"
+
+
+# --- record_lineage ---
+
+
+class TestRecordLineage:
+    def test_basic(self, lineage_path):
+        """Record a simple lineage edge."""
+        result = record_lineage(["expenses"], "spending_report", store_path=lineage_path)
+        assert result["sources"] == ["default.expenses"]
+        assert result["target"] == "default.spending_report"
+        assert result["operation"] == "manual"
+        assert "recorded" in result["message"].lower() or "updated" in result["message"].lower()
+
+    def test_multiple_sources(self, lineage_path):
+        """Record lineage with multiple sources."""
+        result = record_lineage(
+            ["expenses", "categories"], "spending_report",
+            operation="insert_from",
+            store_path=lineage_path,
+        )
+        assert "default.categories" in result["sources"]
+        assert "default.expenses" in result["sources"]
+
+    def test_with_sql(self, lineage_path):
+        """Record lineage with SQL."""
+        sql = "INSERT INTO report SELECT * FROM expenses JOIN categories"
+        result = record_lineage(
+            ["expenses", "categories"], "report",
+            operation="insert_from", sql=sql,
+            store_path=lineage_path,
+        )
+        assert result["sql"] == sql
+
+    def test_normalizes_names(self, lineage_path):
+        """Bare names are auto-prefixed with default."""
+        result = record_lineage(["expenses"], "report", store_path=lineage_path)
+        assert result["sources"] == ["default.expenses"]
+        assert result["target"] == "default.report"
+
+    def test_qualified_names_preserved(self, lineage_path):
+        """Qualified names are preserved as-is."""
+        result = record_lineage(
+            ["analytics.events"], "analytics.summary",
+            store_path=lineage_path,
+        )
+        assert result["sources"] == ["analytics.events"]
+        assert result["target"] == "analytics.summary"
+
+    def test_duplicate_updates(self, lineage_path):
+        """Recording same edge again updates it."""
+        record_lineage(["a"], "b", operation="manual", store_path=lineage_path)
+        result = record_lineage(["a"], "b", operation="pipeline", store_path=lineage_path)
+        assert result["operation"] == "pipeline"
+        assert "updated" in result["message"].lower()
+
+        # Should still be one edge
+        graph = get_lineage_graph(store_path=lineage_path)
+        assert graph["edge_count"] == 1
+
+    def test_deduplicates_sources(self, lineage_path):
+        """Duplicate sources are deduplicated."""
+        result = record_lineage(
+            ["expenses", "expenses"], "report",
+            store_path=lineage_path,
+        )
+        assert result["sources"] == ["default.expenses"]
+
+    def test_sources_sorted(self, lineage_path):
+        """Sources are sorted."""
+        result = record_lineage(
+            ["zebra", "alpha"], "report",
+            store_path=lineage_path,
+        )
+        assert result["sources"] == ["default.alpha", "default.zebra"]
+
+    def test_empty_sources_raises(self, lineage_path):
+        """Empty sources list raises ValueError."""
+        with pytest.raises(ValueError, match="empty"):
+            record_lineage([], "report", store_path=lineage_path)
+
+    def test_empty_target_raises(self, lineage_path):
+        """Empty target raises ValueError."""
+        with pytest.raises(ValueError, match="empty"):
+            record_lineage(["a"], "", store_path=lineage_path)
+
+    def test_has_timestamp(self, lineage_path):
+        """Edge has a recorded_at timestamp."""
+        result = record_lineage(["a"], "b", store_path=lineage_path)
+        assert result["recorded_at"] is not None
+
+    def test_persists(self, lineage_path):
+        """Lineage persists to file."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        assert lineage_path.exists()
+        data = json.loads(lineage_path.read_text())
+        assert len(data["edges"]) == 1
+
+
+# --- get_upstream ---
+
+
+class TestGetUpstream:
+    def test_direct(self, lineage_path):
+        """Get direct upstream dependencies."""
+        record_lineage(["expenses", "categories"], "report", store_path=lineage_path)
+        deps = get_upstream("report", store_path=lineage_path, transitive=False)
+        tables = [d["table"] for d in deps]
+        assert "default.expenses" in tables
+        assert "default.categories" in tables
+
+    def test_transitive(self, lineage_path):
+        """Get transitive upstream dependencies."""
+        # raw_data → cleaned → report
+        record_lineage(["raw_data"], "cleaned", store_path=lineage_path)
+        record_lineage(["cleaned"], "report", store_path=lineage_path)
+        deps = get_upstream("report", store_path=lineage_path)
+        tables = [d["table"] for d in deps]
+        assert "default.cleaned" in tables
+        assert "default.raw_data" in tables
+
+    def test_transitive_depth(self, lineage_path):
+        """Transitive deps include correct depth."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        record_lineage(["b"], "c", store_path=lineage_path)
+        record_lineage(["c"], "d", store_path=lineage_path)
+        deps = get_upstream("d", store_path=lineage_path)
+        depth_map = {d["table"]: d["depth"] for d in deps}
+        assert depth_map["default.c"] == 1
+        assert depth_map["default.b"] == 2
+        assert depth_map["default.a"] == 3
+
+    def test_no_deps(self, lineage_path):
+        """Table with no upstream returns empty."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        deps = get_upstream("a", store_path=lineage_path)
+        assert deps == []
+
+    def test_cycle_detection(self, lineage_path):
+        """Cycles don't cause infinite loops."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        record_lineage(["b"], "c", store_path=lineage_path)
+        record_lineage(["c"], "a", store_path=lineage_path)  # cycle!
+        # Should complete without hanging
+        deps = get_upstream("a", store_path=lineage_path)
+        tables = [d["table"] for d in deps]
+        # Should find upstream of a via the cycle: c → a means c is upstream
+        assert "default.c" in tables
+
+
+# --- get_downstream ---
+
+
+class TestGetDownstream:
+    def test_direct(self, lineage_path):
+        """Get direct downstream dependents."""
+        record_lineage(["expenses"], "report", store_path=lineage_path)
+        record_lineage(["expenses"], "summary", store_path=lineage_path)
+        deps = get_downstream("expenses", store_path=lineage_path, transitive=False)
+        tables = [d["table"] for d in deps]
+        assert "default.report" in tables
+        assert "default.summary" in tables
+
+    def test_transitive(self, lineage_path):
+        """Get transitive downstream dependents."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        record_lineage(["b"], "c", store_path=lineage_path)
+        deps = get_downstream("a", store_path=lineage_path)
+        tables = [d["table"] for d in deps]
+        assert "default.b" in tables
+        assert "default.c" in tables
+
+    def test_no_deps(self, lineage_path):
+        """Table with no downstream returns empty."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        deps = get_downstream("b", store_path=lineage_path)
+        assert deps == []
+
+
+# --- get_lineage_graph ---
+
+
+class TestGetLineageGraph:
+    def test_full_graph(self, lineage_path):
+        """Full graph includes all nodes and edges."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        record_lineage(["b", "c"], "d", store_path=lineage_path)
+        graph = get_lineage_graph(store_path=lineage_path)
+        assert graph["node_count"] == 4
+        assert graph["edge_count"] == 2
+        assert "default.a" in graph["nodes"]
+        assert "default.d" in graph["nodes"]
+
+    def test_empty_graph(self, lineage_path):
+        """Empty store returns empty graph."""
+        graph = get_lineage_graph(store_path=lineage_path)
+        assert graph["nodes"] == []
+        assert graph["edges"] == []
+        assert graph["node_count"] == 0
+        assert graph["edge_count"] == 0
+
+    def test_nodes_sorted(self, lineage_path):
+        """Nodes are sorted."""
+        record_lineage(["zebra"], "alpha", store_path=lineage_path)
+        graph = get_lineage_graph(store_path=lineage_path)
+        assert graph["nodes"] == ["default.alpha", "default.zebra"]
+
+
+# --- remove_lineage ---
+
+
+class TestRemoveLineage:
+    def test_remove_existing(self, lineage_path):
+        """Remove an existing edge."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        result = remove_lineage("a", "b", store_path=lineage_path)
+        assert result["removed"] == 1
+        graph = get_lineage_graph(store_path=lineage_path)
+        assert graph["edge_count"] == 0
+
+    def test_remove_nonexistent(self, lineage_path):
+        """Remove a nonexistent edge."""
+        result = remove_lineage("a", "b", store_path=lineage_path)
+        assert result["removed"] == 0
+
+    def test_remove_preserves_others(self, lineage_path):
+        """Remove only the specified edge."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        record_lineage(["c"], "d", store_path=lineage_path)
+        remove_lineage("a", "b", store_path=lineage_path)
+        graph = get_lineage_graph(store_path=lineage_path)
+        assert graph["edge_count"] == 1
+        assert graph["edges"][0]["target"] == "default.d"
+
+
+# --- get_impact_analysis ---
+
+
+class TestImpactAnalysis:
+    def test_with_downstream(self, lineage_path):
+        """Impact analysis shows affected tables."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        record_lineage(["b"], "c", store_path=lineage_path)
+        record_lineage(["a"], "d", store_path=lineage_path)
+        result = get_impact_analysis("a", store_path=lineage_path)
+        assert result["affected_count"] == 3
+        assert "default.b" in result["affected_tables"]
+        assert "default.c" in result["affected_tables"]
+        assert "default.d" in result["affected_tables"]
+
+    def test_no_downstream(self, lineage_path):
+        """Impact analysis for leaf table."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        result = get_impact_analysis("b", store_path=lineage_path)
+        assert result["affected_count"] == 0
+        assert "no downstream" in result["message"].lower()
+
+    def test_message(self, lineage_path):
+        """Impact message includes count."""
+        record_lineage(["a"], "b", store_path=lineage_path)
+        result = get_impact_analysis("a", store_path=lineage_path)
+        assert "1 table" in result["message"]
+
+
+# --- Storage format ---
+
+
+class TestStorageFormat:
+    def test_json_structure(self, lineage_path):
+        """Lineage store is valid JSON with expected structure."""
+        record_lineage(
+            ["expenses", "categories"], "report",
+            operation="insert_from",
+            sql="SELECT * FROM expenses JOIN categories",
+            store_path=lineage_path,
+        )
+        data = json.loads(lineage_path.read_text())
+        assert "edges" in data
+        assert len(data["edges"]) == 1
+        edge = data["edges"][0]
+        assert edge["sources"] == ["default.categories", "default.expenses"]
+        assert edge["target"] == "default.report"
+        assert edge["operation"] == "insert_from"
+        assert edge["sql"] is not None
+        assert "recorded_at" in edge


### PR DESCRIPTION
## Summary
- Adds `lakehouse/lineage.py` module with table-level dependency graph tracking
- Core functions: record_lineage, get_upstream, get_downstream, get_lineage_graph, remove_lineage, get_impact_analysis
- 7 CLI commands: `lineage add/upstream/downstream/graph/remove/impact`
- 3 MCP tools: `record_lineage`, `get_lineage`, `lineage_graph`
- 30 new tests in `tests/test_lineage.py` (all passing, 602 total suite)

## Test plan
- [x] All 30 lineage tests pass
- [x] Full suite: 602 passed, 1 pre-existing flaky failure
- [x] Transitive closure with BFS (upstream + downstream)
- [x] Cycle detection prevents infinite loops
- [x] Impact analysis shows affected downstream tables
- [x] Duplicate edge recording updates rather than duplicates
- [x] Table name normalization and deduplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)