### PR TITLE
Implement materialized views with freshness tracking

### DIFF
--- a/src/lakehouse/matviews.py
+++ b/src/lakehouse/matviews.py
@@ -1,0 +1,280 @@
+"""Materialized views — cached query results stored as Iceberg tables."""
+
+import datetime
+import json
+import time
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+DEFAULT_MATVIEW_PATH = Path.home() / ".lakehouse" / "materialized_views.json"
+MV_PREFIX = "mv_"
+
+
+def _load_store(store_path: Optional[Path] = None) -> dict:
+    path = store_path or DEFAULT_MATVIEW_PATH
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, KeyError):
+        return {}
+
+
+def _save_store(data: dict, store_path: Optional[Path] = None) -> None:
+    path = store_path or DEFAULT_MATVIEW_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, default=str))
+
+
+def _backing_table_name(name: str, namespace: str = "default") -> str:
+    return f"{namespace}.{MV_PREFIX}{name}"
+
+
+def _get_source_snapshot_ids(catalog, sql: str) -> dict:
+    """Try to identify source tables and their current snapshot IDs."""
+    from .catalog import list_tables
+    snapshots = {}
+    all_tables = list_tables(catalog, namespace="*")
+    sql_lower = sql.lower()
+    for tbl in all_tables:
+        short = tbl.split(".")[-1]
+        if short.lower() in sql_lower:
+            try:
+                table = catalog.load_table(tbl)
+                snap = table.current_snapshot()
+                if snap:
+                    snapshots[tbl] = snap.snapshot_id
+            except Exception:
+                pass
+    return snapshots
+
+
+def create_materialized_view(
+    name: str,
+    sql: str,
+    engine,
+    catalog,
+    description: str = "",
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Create a materialized view by executing SQL and storing results.
+
+    Args:
+        name: View name
+        sql: SQL SELECT query
+        engine: QueryEngine instance
+        catalog: Iceberg catalog
+        description: Optional description
+        store_path: Optional path to metadata store
+
+    Returns:
+        Dict with view details.
+    """
+    if not name or not name.strip():
+        raise ValueError("View name must not be empty")
+    if not sql or not sql.strip():
+        raise ValueError("SQL must not be empty")
+
+    store = _load_store(store_path)
+    if name in store:
+        raise ValueError(f"Materialized view '{name}' already exists")
+
+    # Execute SQL to get results
+    df = engine.execute(sql, max_rows=1_000_000)
+    backing_table = _backing_table_name(name)
+
+    # Infer column types and create backing table
+    from .catalog import create_table, insert_rows
+    type_map = {
+        "int64": "long",
+        "float64": "double",
+        "object": "string",
+        "bool": "boolean",
+    }
+    columns = {}
+    for col in df.columns:
+        dtype = str(df[col].dtype)
+        columns[col] = type_map.get(dtype, "string")
+
+    create_table(catalog, backing_table, columns)
+
+    # Insert data
+    if not df.empty:
+        rows = df.to_dict(orient="records")
+        insert_rows(catalog, backing_table, rows)
+
+    # Get source snapshot IDs for freshness tracking
+    source_snapshots = _get_source_snapshot_ids(catalog, sql)
+
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    store[name] = {
+        "sql": sql,
+        "description": description,
+        "backing_table": backing_table,
+        "created_at": now,
+        "last_refreshed": now,
+        "row_count": len(df),
+        "source_snapshot_ids": source_snapshots,
+    }
+    _save_store(store, store_path)
+
+    return {
+        "name": name,
+        "sql": sql,
+        "description": description,
+        "backing_table": backing_table,
+        "row_count": len(df),
+        "created_at": now,
+        "message": f"Created materialized view '{name}' ({len(df)} rows)",
+    }
+
+
+def refresh_materialized_view(
+    name: str,
+    engine,
+    catalog,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Re-execute the view SQL and replace the backing table data."""
+    store = _load_store(store_path)
+    if name not in store:
+        raise ValueError(f"Materialized view '{name}' not found")
+
+    entry = store[name]
+    sql = entry["sql"]
+    backing_table = entry["backing_table"]
+
+    start = time.time()
+    rows_before = entry.get("row_count", 0)
+
+    # Re-execute SQL
+    df = engine.execute(sql, max_rows=1_000_000)
+
+    # Overwrite backing table
+    from .catalog import delete_rows, insert_rows
+    try:
+        delete_rows(catalog, backing_table, "1=1")
+    except Exception:
+        pass
+
+    if not df.empty:
+        rows = df.to_dict(orient="records")
+        insert_rows(catalog, backing_table, rows)
+
+    duration_ms = int((time.time() - start) * 1000)
+
+    # Update metadata
+    source_snapshots = _get_source_snapshot_ids(catalog, sql)
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    entry["last_refreshed"] = now
+    entry["row_count"] = len(df)
+    entry["source_snapshot_ids"] = source_snapshots
+    _save_store(store, store_path)
+
+    return {
+        "name": name,
+        "rows_before": rows_before,
+        "rows_after": len(df),
+        "duration_ms": duration_ms,
+        "last_refreshed": now,
+        "message": f"Refreshed '{name}': {rows_before} → {len(df)} rows ({duration_ms}ms)",
+    }
+
+
+def list_materialized_views(
+    store_path: Optional[Path] = None,
+) -> list[dict]:
+    """List all materialized views."""
+    store = _load_store(store_path)
+    result = []
+    for name, entry in sorted(store.items()):
+        result.append({
+            "name": name,
+            "sql": entry["sql"],
+            "description": entry.get("description", ""),
+            "backing_table": entry["backing_table"],
+            "row_count": entry.get("row_count", 0),
+            "created_at": entry.get("created_at", ""),
+            "last_refreshed": entry.get("last_refreshed", ""),
+        })
+    return result
+
+
+def drop_materialized_view(
+    name: str,
+    catalog,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Drop a materialized view and its backing table."""
+    store = _load_store(store_path)
+    if name not in store:
+        raise ValueError(f"Materialized view '{name}' not found")
+
+    backing_table = store[name]["backing_table"]
+
+    # Drop backing table
+    try:
+        catalog.drop_table(backing_table)
+    except Exception:
+        pass  # Backing table may not exist
+
+    del store[name]
+    _save_store(store, store_path)
+
+    return {
+        "name": name,
+        "message": f"Dropped materialized view '{name}'",
+    }
+
+
+def query_materialized_view(
+    name: str,
+    engine,
+    max_rows: int = 1000,
+    store_path: Optional[Path] = None,
+) -> pd.DataFrame:
+    """Query the cached results of a materialized view (fast, no re-execution)."""
+    store = _load_store(store_path)
+    if name not in store:
+        raise ValueError(f"Materialized view '{name}' not found")
+
+    backing_table = store[name]["backing_table"]
+    short_name = backing_table.split(".")[-1]
+    return engine.execute(f"SELECT * FROM {short_name}", max_rows=max_rows)
+
+
+def check_materialized_view_freshness(
+    name: str,
+    catalog,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Check if a materialized view is stale."""
+    store = _load_store(store_path)
+    if name not in store:
+        raise ValueError(f"Materialized view '{name}' not found")
+
+    entry = store[name]
+    stored_snapshots = entry.get("source_snapshot_ids", {})
+    current_snapshots = _get_source_snapshot_ids(catalog, entry["sql"])
+
+    stale = False
+    changed_tables = []
+    for tbl, snap_id in current_snapshots.items():
+        stored_id = stored_snapshots.get(tbl)
+        if stored_id != snap_id:
+            stale = True
+            changed_tables.append(tbl)
+
+    return {
+        "name": name,
+        "stale": stale,
+        "changed_tables": changed_tables,
+        "last_refreshed": entry.get("last_refreshed", ""),
+        "message": (
+            f"'{name}' is stale ({len(changed_tables)} source table(s) changed)"
+            if stale
+            else f"'{name}' is fresh"
+        ),
+    }

--- a/tests/test_matviews.py
+++ b/tests/test_matviews.py
@@ -1,0 +1,241 @@
+"""Tests for materialized views."""
+
+import json
+import pytest
+from pathlib import Path
+
+from lakehouse.matviews import (
+    create_materialized_view,
+    refresh_materialized_view,
+    list_materialized_views,
+    drop_materialized_view,
+    query_materialized_view,
+    check_materialized_view_freshness,
+)
+from lakehouse.catalog import create_table, insert_rows, list_tables
+from lakehouse.query import QueryEngine
+
+
+@pytest.fixture
+def mv_path(tmp_path):
+    """Return a temporary materialized views store path."""
+    return tmp_path / "materialized_views.json"
+
+
+@pytest.fixture
+def mv_data(test_catalog):
+    """Create source tables with data for materialized view tests."""
+    create_table(test_catalog, "mv_source", columns={"id": "long", "category": "string", "amount": "double"})
+    insert_rows(test_catalog, "default.mv_source", [
+        {"id": 1, "category": "food", "amount": 10.0},
+        {"id": 2, "category": "food", "amount": 20.0},
+        {"id": 3, "category": "travel", "amount": 30.0},
+    ])
+    return test_catalog
+
+
+# --- create_materialized_view ---
+
+
+class TestCreateMaterializedView:
+    def test_basic(self, mv_data, mv_path):
+        """Create a materialized view."""
+        engine = QueryEngine(catalog=mv_data)
+        result = create_materialized_view(
+            "totals", "SELECT category, SUM(amount) AS total FROM mv_source GROUP BY category",
+            engine, mv_data, store_path=mv_path,
+        )
+        assert result["name"] == "totals"
+        assert result["row_count"] == 2
+        assert "mv_totals" in result["backing_table"]
+        assert "created" in result["message"].lower()
+
+    def test_with_description(self, mv_data, mv_path):
+        """Create with description."""
+        engine = QueryEngine(catalog=mv_data)
+        result = create_materialized_view(
+            "desc_view", "SELECT * FROM mv_source",
+            engine, mv_data, description="My view", store_path=mv_path,
+        )
+        assert result["description"] == "My view"
+
+    def test_duplicate_raises(self, mv_data, mv_path):
+        """Duplicate name raises ValueError."""
+        engine = QueryEngine(catalog=mv_data)
+        create_materialized_view("dupe", "SELECT 1 AS val", engine, mv_data, store_path=mv_path)
+        with pytest.raises(ValueError, match="already exists"):
+            create_materialized_view("dupe", "SELECT 2 AS val", engine, mv_data, store_path=mv_path)
+
+    def test_empty_name_raises(self, mv_data, mv_path):
+        """Empty name raises ValueError."""
+        engine = QueryEngine(catalog=mv_data)
+        with pytest.raises(ValueError, match="empty"):
+            create_materialized_view("", "SELECT 1", engine, mv_data, store_path=mv_path)
+
+    def test_empty_sql_raises(self, mv_data, mv_path):
+        """Empty SQL raises ValueError."""
+        engine = QueryEngine(catalog=mv_data)
+        with pytest.raises(ValueError, match="empty"):
+            create_materialized_view("test", "", engine, mv_data, store_path=mv_path)
+
+    def test_creates_backing_table(self, mv_data, mv_path):
+        """Backing table is created in catalog."""
+        engine = QueryEngine(catalog=mv_data)
+        create_materialized_view("backed", "SELECT * FROM mv_source", engine, mv_data, store_path=mv_path)
+        tables = list_tables(mv_data)
+        assert "default.mv_backed" in tables
+
+
+# --- query_materialized_view ---
+
+
+class TestQueryMaterializedView:
+    def test_returns_cached_data(self, mv_data, mv_path):
+        """Query returns cached results."""
+        engine = QueryEngine(catalog=mv_data)
+        create_materialized_view(
+            "cached", "SELECT category, SUM(amount) AS total FROM mv_source GROUP BY category",
+            engine, mv_data, store_path=mv_path,
+        )
+        # Re-create engine to pick up new table
+        engine2 = QueryEngine(catalog=mv_data)
+        df = query_materialized_view("cached", engine2, store_path=mv_path)
+        assert len(df) == 2
+
+    def test_nonexistent_raises(self, mv_data, mv_path):
+        """Query nonexistent view raises ValueError."""
+        engine = QueryEngine(catalog=mv_data)
+        with pytest.raises(ValueError, match="not found"):
+            query_materialized_view("no_such", engine, store_path=mv_path)
+
+
+# --- refresh_materialized_view ---
+
+
+class TestRefreshMaterializedView:
+    def test_refresh_picks_up_changes(self, mv_data, mv_path):
+        """Refresh picks up new data."""
+        engine = QueryEngine(catalog=mv_data)
+        create_materialized_view(
+            "refresh_test", "SELECT * FROM mv_source",
+            engine, mv_data, store_path=mv_path,
+        )
+        # Add more data
+        insert_rows(mv_data, "default.mv_source", [
+            {"id": 4, "category": "misc", "amount": 40.0},
+        ])
+        # Refresh with new engine
+        engine2 = QueryEngine(catalog=mv_data)
+        result = refresh_materialized_view("refresh_test", engine2, mv_data, store_path=mv_path)
+        assert result["rows_before"] == 3
+        assert result["rows_after"] == 4
+        assert "refreshed" in result["message"].lower()
+
+    def test_nonexistent_raises(self, mv_data, mv_path):
+        """Refresh nonexistent view raises ValueError."""
+        engine = QueryEngine(catalog=mv_data)
+        with pytest.raises(ValueError, match="not found"):
+            refresh_materialized_view("no_such", engine, mv_data, store_path=mv_path)
+
+
+# --- check_materialized_view_freshness ---
+
+
+class TestFreshnessCheck:
+    def test_fresh(self, mv_data, mv_path):
+        """Freshly created view is not stale."""
+        engine = QueryEngine(catalog=mv_data)
+        create_materialized_view(
+            "fresh_check", "SELECT * FROM mv_source",
+            engine, mv_data, store_path=mv_path,
+        )
+        result = check_materialized_view_freshness("fresh_check", mv_data, store_path=mv_path)
+        assert result["stale"] is False
+
+    def test_stale_after_insert(self, mv_data, mv_path):
+        """View becomes stale when source data changes."""
+        engine = QueryEngine(catalog=mv_data)
+        create_materialized_view(
+            "stale_check", "SELECT * FROM mv_source",
+            engine, mv_data, store_path=mv_path,
+        )
+        # Modify source
+        insert_rows(mv_data, "default.mv_source", [{"id": 5, "category": "new", "amount": 50.0}])
+        result = check_materialized_view_freshness("stale_check", mv_data, store_path=mv_path)
+        assert result["stale"] is True
+        assert "default.mv_source" in result["changed_tables"]
+
+
+# --- list_materialized_views ---
+
+
+class TestListMaterializedViews:
+    def test_empty(self, mv_path):
+        """Empty store returns empty list."""
+        assert list_materialized_views(store_path=mv_path) == []
+
+    def test_with_views(self, mv_data, mv_path):
+        """List created views."""
+        engine = QueryEngine(catalog=mv_data)
+        create_materialized_view("v1", "SELECT 1 AS val", engine, mv_data, store_path=mv_path)
+        create_materialized_view("v2", "SELECT 2 AS val", engine, mv_data, store_path=mv_path)
+        views = list_materialized_views(store_path=mv_path)
+        assert len(views) == 2
+        names = [v["name"] for v in views]
+        assert "v1" in names
+        assert "v2" in names
+
+    def test_includes_fields(self, mv_data, mv_path):
+        """List includes expected fields."""
+        engine = QueryEngine(catalog=mv_data)
+        create_materialized_view("fields_check", "SELECT 1 AS val", engine, mv_data, store_path=mv_path)
+        views = list_materialized_views(store_path=mv_path)
+        v = views[0]
+        assert "name" in v
+        assert "sql" in v
+        assert "row_count" in v
+        assert "last_refreshed" in v
+
+
+# --- drop_materialized_view ---
+
+
+class TestDropMaterializedView:
+    def test_drop(self, mv_data, mv_path):
+        """Drop removes view and backing table."""
+        engine = QueryEngine(catalog=mv_data)
+        create_materialized_view("to_drop", "SELECT 1 AS val", engine, mv_data, store_path=mv_path)
+        result = drop_materialized_view("to_drop", mv_data, store_path=mv_path)
+        assert "dropped" in result["message"].lower()
+
+        # Backing table should be gone
+        tables = list_tables(mv_data)
+        assert "default.mv_to_drop" not in tables
+
+    def test_drop_nonexistent_raises(self, mv_data, mv_path):
+        """Drop nonexistent raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            drop_materialized_view("no_such", mv_data, store_path=mv_path)
+
+
+# --- Storage format ---
+
+
+class TestStorageFormat:
+    def test_json_structure(self, mv_data, mv_path):
+        """Store is valid JSON with expected structure."""
+        engine = QueryEngine(catalog=mv_data)
+        create_materialized_view(
+            "json_check", "SELECT * FROM mv_source",
+            engine, mv_data, description="test", store_path=mv_path,
+        )
+        data = json.loads(mv_path.read_text())
+        assert "json_check" in data
+        entry = data["json_check"]
+        assert entry["sql"] == "SELECT * FROM mv_source"
+        assert entry["description"] == "test"
+        assert entry["backing_table"] == "default.mv_json_check"
+        assert entry["row_count"] == 3
+        assert "created_at" in entry
+        assert "last_refreshed" in entry
+        assert "source_snapshot_ids" in entry


### PR DESCRIPTION
## Summary
- Adds materialized views backed by real Iceberg tables (`mv_` prefix) with JSON metadata store
- Snapshot-based freshness detection compares source table snapshot IDs at creation vs current
- 6 core functions: create, refresh, query, list, drop, check freshness
- 6 CLI commands under `matview` group
- 5 MCP tools: create_materialized_view, list_materialized_views, query_materialized_view, refresh_materialized_view, drop_materialized_view

Closes #65

## Test plan
- [x] 18 unit tests covering all operations (create, query, refresh, freshness, list, drop, storage format)
- [x] Full suite: 655 passed (1 pre-existing flaky failure in test_expire_retain_last — upstream PyIceberg issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)