### PR TITLE
Implement data catalog enrichment (#82)

### DIFF
--- a/src/lakehouse/catalog_metadata.py
+++ b/src/lakehouse/catalog_metadata.py
@@ -1,0 +1,269 @@
+"""Data catalog enrichment — column descriptions, glossary, and data classification."""
+
+import datetime
+import json
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_CATALOG_META_PATH = Path.home() / ".lakehouse" / "catalog_metadata.json"
+
+VALID_CLASSIFICATIONS = {"pii", "financial", "public", "internal", "confidential"}
+
+
+def _load_store(store_path: Optional[Path] = None) -> dict:
+    path = store_path or DEFAULT_CATALOG_META_PATH
+    if not path.exists():
+        return {"column_descriptions": {}, "classifications": {}, "glossary": {}}
+    try:
+        data = json.loads(path.read_text())
+        data.setdefault("column_descriptions", {})
+        data.setdefault("classifications", {})
+        data.setdefault("glossary", {})
+        return data
+    except (json.JSONDecodeError, KeyError):
+        return {"column_descriptions": {}, "classifications": {}, "glossary": {}}
+
+
+def _save_store(data: dict, store_path: Optional[Path] = None) -> None:
+    path = store_path or DEFAULT_CATALOG_META_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, default=str))
+
+
+def _normalize(table_name: str) -> str:
+    if "." not in table_name:
+        return f"default.{table_name}"
+    return table_name
+
+
+# --- Column Descriptions ---
+
+
+def set_column_description(
+    table_name: str,
+    column_name: str,
+    description: str,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Set a description for a table column."""
+    table_name = _normalize(table_name)
+    store = _load_store(store_path)
+
+    if table_name not in store["column_descriptions"]:
+        store["column_descriptions"][table_name] = {}
+    store["column_descriptions"][table_name][column_name] = description
+    _save_store(store, store_path)
+
+    return {
+        "table": table_name,
+        "column": column_name,
+        "description": description,
+        "message": f"Description set for '{table_name}.{column_name}'",
+    }
+
+
+def get_column_descriptions(
+    table_name: str,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Get all column descriptions for a table."""
+    table_name = _normalize(table_name)
+    store = _load_store(store_path)
+    descriptions = store["column_descriptions"].get(table_name, {})
+    return {
+        "table": table_name,
+        "descriptions": descriptions,
+        "message": f"{len(descriptions)} description(s) for '{table_name}'",
+    }
+
+
+# --- Classifications ---
+
+
+def classify_column(
+    table_name: str,
+    column_name: str,
+    classification: str,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Set data classification for a column."""
+    if classification not in VALID_CLASSIFICATIONS:
+        raise ValueError(
+            f"Invalid classification '{classification}'. "
+            f"Must be one of: {', '.join(sorted(VALID_CLASSIFICATIONS))}"
+        )
+
+    table_name = _normalize(table_name)
+    store = _load_store(store_path)
+
+    if table_name not in store["classifications"]:
+        store["classifications"][table_name] = {}
+    store["classifications"][table_name][column_name] = classification
+    _save_store(store, store_path)
+
+    return {
+        "table": table_name,
+        "column": column_name,
+        "classification": classification,
+        "message": f"Column '{column_name}' classified as '{classification}'",
+    }
+
+
+def get_classifications(
+    table_name: Optional[str] = None,
+    classification: Optional[str] = None,
+    store_path: Optional[Path] = None,
+) -> list[dict]:
+    """Get classifications, optionally filtered by table or classification type."""
+    store = _load_store(store_path)
+    results = []
+
+    tables = store["classifications"]
+    if table_name:
+        table_name = _normalize(table_name)
+        tables = {table_name: tables.get(table_name, {})}
+
+    for tbl, cols in tables.items():
+        for col, cls in cols.items():
+            if classification and cls != classification:
+                continue
+            results.append({
+                "table": tbl,
+                "column": col,
+                "classification": cls,
+            })
+
+    return results
+
+
+# --- Glossary ---
+
+
+def add_glossary_term(
+    term: str,
+    definition: str,
+    aliases: Optional[list[str]] = None,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Add a business glossary term."""
+    store = _load_store(store_path)
+    store["glossary"][term] = {
+        "definition": definition,
+        "aliases": aliases or [],
+        "created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    _save_store(store, store_path)
+
+    return {
+        "term": term,
+        "definition": definition,
+        "aliases": aliases or [],
+        "message": f"Glossary term '{term}' added",
+    }
+
+
+def search_glossary(
+    query: str,
+    store_path: Optional[Path] = None,
+) -> list[dict]:
+    """Search glossary terms by name, alias, or definition text (case-insensitive)."""
+    store = _load_store(store_path)
+    query_lower = query.lower()
+    results = []
+
+    for term, info in store["glossary"].items():
+        matches = False
+        if query_lower in term.lower():
+            matches = True
+        elif query_lower in info["definition"].lower():
+            matches = True
+        elif any(query_lower in a.lower() for a in info.get("aliases", [])):
+            matches = True
+
+        if matches:
+            results.append({
+                "term": term,
+                "definition": info["definition"],
+                "aliases": info.get("aliases", []),
+            })
+
+    return results
+
+
+def list_glossary(store_path: Optional[Path] = None) -> list[dict]:
+    """List all glossary terms."""
+    store = _load_store(store_path)
+    return [
+        {
+            "term": term,
+            "definition": info["definition"],
+            "aliases": info.get("aliases", []),
+        }
+        for term, info in store["glossary"].items()
+    ]
+
+
+def remove_glossary_term(
+    term: str,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Remove a glossary term."""
+    store = _load_store(store_path)
+    if term in store["glossary"]:
+        del store["glossary"][term]
+        _save_store(store, store_path)
+        return {"term": term, "message": f"Glossary term '{term}' removed"}
+    return {"term": term, "message": f"Glossary term '{term}' not found"}
+
+
+# --- Enriched Schema ---
+
+
+def get_enriched_schema(
+    catalog,
+    table_name: str,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Get table schema enriched with descriptions, classifications, and glossary matches."""
+    table_name = _normalize(table_name)
+
+    try:
+        table = catalog.load_table(table_name)
+    except Exception as e:
+        raise ValueError(f"Table '{table_name}' not found: {e}")
+
+    schema = table.schema()
+    store = _load_store(store_path)
+
+    descriptions = store["column_descriptions"].get(table_name, {})
+    classifications = store["classifications"].get(table_name, {})
+
+    fields = []
+    for field in schema.fields:
+        # Check for glossary matches in the column name
+        glossary_matches = []
+        for term, info in store["glossary"].items():
+            term_lower = term.lower()
+            if term_lower in field.name.lower():
+                glossary_matches.append(term)
+            elif any(a.lower() in field.name.lower() for a in info.get("aliases", [])):
+                glossary_matches.append(term)
+
+        fields.append({
+            "field_id": field.field_id,
+            "name": field.name,
+            "type": str(field.field_type),
+            "required": field.required,
+            "description": descriptions.get(field.name),
+            "classification": classifications.get(field.name),
+            "glossary_matches": glossary_matches,
+        })
+
+    return {
+        "table": table_name,
+        "fields": fields,
+        "total_fields": len(fields),
+        "described_fields": sum(1 for f in fields if f["description"]),
+        "classified_fields": sum(1 for f in fields if f["classification"]),
+        "message": f"Enriched schema for '{table_name}': {len(fields)} fields",
+    }

--- a/tests/test_catalog_metadata.py
+++ b/tests/test_catalog_metadata.py
@@ -1,0 +1,198 @@
+"""Tests for data catalog enrichment (descriptions, glossary, classifications)."""
+
+import json
+import pytest
+
+from lakehouse.catalog_metadata import (
+    set_column_description,
+    get_column_descriptions,
+    classify_column,
+    get_classifications,
+    add_glossary_term,
+    search_glossary,
+    list_glossary,
+    remove_glossary_term,
+    get_enriched_schema,
+)
+from lakehouse.catalog import create_table, insert_rows
+
+
+@pytest.fixture
+def meta_path(tmp_path):
+    """Return a temporary catalog metadata store path."""
+    return tmp_path / "catalog_metadata.json"
+
+
+@pytest.fixture
+def enriched_table(test_catalog, meta_path):
+    """Create a table with descriptions and classifications."""
+    create_table(test_catalog, "users", columns={"id": "long", "name": "string", "email": "string"})
+    insert_rows(test_catalog, "default.users", [{"id": 1, "name": "Alice", "email": "alice@test.com"}])
+    set_column_description("users", "id", "Unique user identifier", store_path=meta_path)
+    set_column_description("users", "email", "User email address", store_path=meta_path)
+    classify_column("users", "email", "pii", store_path=meta_path)
+    classify_column("users", "name", "pii", store_path=meta_path)
+    return test_catalog
+
+
+# --- Column Descriptions ---
+
+
+class TestColumnDescriptions:
+    def test_set_and_get(self, meta_path):
+        """Set and retrieve a column description."""
+        set_column_description("t", "col1", "A description", store_path=meta_path)
+        result = get_column_descriptions("t", store_path=meta_path)
+        assert result["descriptions"]["col1"] == "A description"
+
+    def test_multiple_columns(self, meta_path):
+        """Set descriptions for multiple columns."""
+        set_column_description("t", "a", "Column A", store_path=meta_path)
+        set_column_description("t", "b", "Column B", store_path=meta_path)
+        result = get_column_descriptions("t", store_path=meta_path)
+        assert len(result["descriptions"]) == 2
+
+    def test_overwrite(self, meta_path):
+        """Overwriting a description replaces the old one."""
+        set_column_description("t", "col", "Old", store_path=meta_path)
+        set_column_description("t", "col", "New", store_path=meta_path)
+        result = get_column_descriptions("t", store_path=meta_path)
+        assert result["descriptions"]["col"] == "New"
+
+    def test_empty_table(self, meta_path):
+        """Getting descriptions for a table with none returns empty."""
+        result = get_column_descriptions("no_such", store_path=meta_path)
+        assert result["descriptions"] == {}
+
+    def test_message(self, meta_path):
+        """Result includes a message."""
+        result = set_column_description("t", "col", "desc", store_path=meta_path)
+        assert "description set" in result["message"].lower()
+
+
+# --- Classifications ---
+
+
+class TestClassifications:
+    def test_classify_valid(self, meta_path):
+        """Classify a column with a valid classification."""
+        result = classify_column("t", "email", "pii", store_path=meta_path)
+        assert result["classification"] == "pii"
+
+    def test_invalid_classification_raises(self, meta_path):
+        """Invalid classification raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid classification"):
+            classify_column("t", "col", "secret", store_path=meta_path)
+
+    def test_get_by_table(self, meta_path):
+        """Get classifications filtered by table."""
+        classify_column("t1", "a", "pii", store_path=meta_path)
+        classify_column("t2", "b", "financial", store_path=meta_path)
+        results = get_classifications(table_name="t1", store_path=meta_path)
+        assert len(results) == 1
+        assert results[0]["table"] == "default.t1"
+
+    def test_get_by_type(self, meta_path):
+        """Get classifications filtered by type."""
+        classify_column("t", "a", "pii", store_path=meta_path)
+        classify_column("t", "b", "financial", store_path=meta_path)
+        classify_column("t", "c", "pii", store_path=meta_path)
+        results = get_classifications(classification="pii", store_path=meta_path)
+        assert len(results) == 2
+
+
+# --- Glossary ---
+
+
+class TestGlossary:
+    def test_add_and_search(self, meta_path):
+        """Add a term and find it by search."""
+        add_glossary_term("MRR", "Monthly Recurring Revenue", store_path=meta_path)
+        results = search_glossary("MRR", store_path=meta_path)
+        assert len(results) == 1
+        assert results[0]["term"] == "MRR"
+
+    def test_search_by_definition(self, meta_path):
+        """Search matches on definition text."""
+        add_glossary_term("MRR", "Monthly Recurring Revenue", store_path=meta_path)
+        results = search_glossary("revenue", store_path=meta_path)
+        assert len(results) == 1
+
+    def test_search_by_alias(self, meta_path):
+        """Search matches on aliases."""
+        add_glossary_term("MRR", "Monthly Recurring Revenue", aliases=["monthly revenue"], store_path=meta_path)
+        results = search_glossary("monthly revenue", store_path=meta_path)
+        assert len(results) == 1
+
+    def test_list_glossary(self, meta_path):
+        """List all glossary terms."""
+        add_glossary_term("A", "Term A", store_path=meta_path)
+        add_glossary_term("B", "Term B", store_path=meta_path)
+        terms = list_glossary(store_path=meta_path)
+        assert len(terms) == 2
+
+    def test_remove_glossary(self, meta_path):
+        """Remove a glossary term."""
+        add_glossary_term("MRR", "Monthly Recurring Revenue", store_path=meta_path)
+        remove_glossary_term("MRR", store_path=meta_path)
+        assert list_glossary(store_path=meta_path) == []
+
+    def test_remove_nonexistent(self, meta_path):
+        """Removing a nonexistent term is a no-op."""
+        result = remove_glossary_term("nope", store_path=meta_path)
+        assert "not found" in result["message"].lower()
+
+
+# --- Enriched Schema ---
+
+
+class TestEnrichedSchema:
+    def test_includes_descriptions(self, enriched_table, meta_path):
+        """Enriched schema includes column descriptions."""
+        result = get_enriched_schema(enriched_table, "users", store_path=meta_path)
+        email_field = next(f for f in result["fields"] if f["name"] == "email")
+        assert email_field["description"] == "User email address"
+
+    def test_includes_classifications(self, enriched_table, meta_path):
+        """Enriched schema includes classifications."""
+        result = get_enriched_schema(enriched_table, "users", store_path=meta_path)
+        email_field = next(f for f in result["fields"] if f["name"] == "email")
+        assert email_field["classification"] == "pii"
+
+    def test_includes_glossary_matches(self, enriched_table, meta_path):
+        """Enriched schema includes glossary term matches."""
+        add_glossary_term("email", "Electronic mail address", store_path=meta_path)
+        result = get_enriched_schema(enriched_table, "users", store_path=meta_path)
+        email_field = next(f for f in result["fields"] if f["name"] == "email")
+        assert "email" in email_field["glossary_matches"]
+
+    def test_counts(self, enriched_table, meta_path):
+        """Enriched schema includes field counts."""
+        result = get_enriched_schema(enriched_table, "users", store_path=meta_path)
+        assert result["total_fields"] == 3
+        assert result["described_fields"] == 2
+        assert result["classified_fields"] == 2
+
+    def test_nonexistent_table_raises(self, test_catalog, meta_path):
+        """Nonexistent table raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            get_enriched_schema(test_catalog, "no_such", store_path=meta_path)
+
+
+# --- Storage format ---
+
+
+class TestStorageFormat:
+    def test_json_structure(self, meta_path):
+        """Store is valid JSON with expected structure."""
+        set_column_description("t", "col", "desc", store_path=meta_path)
+        classify_column("t", "col", "pii", store_path=meta_path)
+        add_glossary_term("Term", "Definition", store_path=meta_path)
+
+        data = json.loads(meta_path.read_text())
+        assert "column_descriptions" in data
+        assert "classifications" in data
+        assert "glossary" in data
+        assert "default.t" in data["column_descriptions"]
+        assert "default.t" in data["classifications"]
+        assert "Term" in data["glossary"]


### PR DESCRIPTION
## Summary
- Add `catalog_metadata.py` with 9 functions: column descriptions, data classifications (pii/financial/public/internal/confidential), business glossary, and enriched schema
- 21 tests covering descriptions, classifications, glossary CRUD, enriched schema, and storage format
- CLI commands: `catalog describe-column`, `column-descriptions`, `classify`, `classifications`, `glossary add/search/list/remove`, `enriched-schema`
- MCP tools: `set_column_description`, `classify_column`, `get_enriched_schema`, `search_glossary`

## Test plan
- [x] 21/21 catalog metadata tests pass
- [x] Full suite: 763 passed, 2 failed (pre-existing upstream PyIceberg `expire_snapshots` flaky issue)

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)