### PR TITLE
Implement incremental processing with watermarks (#84)

### DIFF
--- a/src/lakehouse/incremental.py
+++ b/src/lakehouse/incremental.py
@@ -1,0 +1,361 @@
+"""Incremental processing — watermark-based pipeline runs."""
+
+import datetime
+import json
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_WATERMARK_PATH = Path.home() / ".lakehouse" / "watermarks.json"
+
+
+def _load_store(store_path: Optional[Path] = None) -> dict:
+    path = store_path or DEFAULT_WATERMARK_PATH
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, KeyError):
+        return {}
+
+
+def _save_store(data: dict, store_path: Optional[Path] = None) -> None:
+    path = store_path or DEFAULT_WATERMARK_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, default=str))
+
+
+def _normalize(table_name: str) -> str:
+    if "." not in table_name:
+        return f"default.{table_name}"
+    return table_name
+
+
+def set_watermark(
+    pipeline_name: str,
+    table_name: str,
+    snapshot_id: int,
+    rows_processed: int = 0,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Record the last-processed snapshot ID for a pipeline/table pair."""
+    table_name = _normalize(table_name)
+    store = _load_store(store_path)
+
+    if pipeline_name not in store:
+        store[pipeline_name] = {}
+
+    store[pipeline_name][table_name] = {
+        "snapshot_id": snapshot_id,
+        "processed_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "rows_processed": rows_processed,
+    }
+    _save_store(store, store_path)
+
+    return {
+        "pipeline": pipeline_name,
+        "table": table_name,
+        "snapshot_id": snapshot_id,
+        "message": f"Watermark set for '{pipeline_name}/{table_name}' at snapshot {snapshot_id}",
+    }
+
+
+def get_watermark(
+    pipeline_name: str,
+    table_name: str,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Get the last-processed snapshot ID."""
+    table_name = _normalize(table_name)
+    store = _load_store(store_path)
+    pipeline_data = store.get(pipeline_name, {})
+    watermark = pipeline_data.get(table_name)
+
+    if watermark is None:
+        return {
+            "pipeline": pipeline_name,
+            "table": table_name,
+            "snapshot_id": None,
+            "message": f"No watermark for '{pipeline_name}/{table_name}'",
+        }
+
+    return {
+        "pipeline": pipeline_name,
+        "table": table_name,
+        "snapshot_id": watermark["snapshot_id"],
+        "processed_at": watermark.get("processed_at"),
+        "rows_processed": watermark.get("rows_processed", 0),
+        "message": f"Watermark for '{pipeline_name}/{table_name}': snapshot {watermark['snapshot_id']}",
+    }
+
+
+def list_watermarks(
+    pipeline_name: Optional[str] = None,
+    store_path: Optional[Path] = None,
+) -> list[dict]:
+    """List all watermarks, optionally filtered by pipeline."""
+    store = _load_store(store_path)
+    results = []
+
+    pipelines = store
+    if pipeline_name:
+        pipelines = {pipeline_name: store.get(pipeline_name, {})}
+
+    for pname, tables in pipelines.items():
+        for tbl, wm in tables.items():
+            results.append({
+                "pipeline": pname,
+                "table": tbl,
+                "snapshot_id": wm["snapshot_id"],
+                "processed_at": wm.get("processed_at"),
+                "rows_processed": wm.get("rows_processed", 0),
+            })
+
+    return results
+
+
+def reset_watermark(
+    pipeline_name: str,
+    table_name: Optional[str] = None,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Reset watermark to force full reprocessing."""
+    store = _load_store(store_path)
+
+    if pipeline_name not in store:
+        return {"pipeline": pipeline_name, "message": f"No watermarks found for pipeline '{pipeline_name}'"}
+
+    if table_name:
+        table_name = _normalize(table_name)
+        if table_name in store[pipeline_name]:
+            del store[pipeline_name][table_name]
+            if not store[pipeline_name]:
+                del store[pipeline_name]
+            _save_store(store, store_path)
+            return {"pipeline": pipeline_name, "table": table_name, "message": f"Watermark reset for '{pipeline_name}/{table_name}'"}
+        return {"pipeline": pipeline_name, "table": table_name, "message": f"No watermark found for '{pipeline_name}/{table_name}'"}
+    else:
+        del store[pipeline_name]
+        _save_store(store, store_path)
+        return {"pipeline": pipeline_name, "message": f"All watermarks reset for pipeline '{pipeline_name}'"}
+
+
+def get_incremental_data(
+    catalog,
+    table_name: str,
+    pipeline_name: str,
+    store_path: Optional[Path] = None,
+) -> dict:
+    """Get only new rows since the last watermark.
+
+    Uses Iceberg snapshot-based reads to get rows added between
+    the watermarked snapshot and the current snapshot.
+
+    Returns:
+        Dict with dataframe, row_count, from_snapshot, to_snapshot.
+    """
+    from .catalog import scan_as_of
+
+    table_name = _normalize(table_name)
+
+    try:
+        table = catalog.load_table(table_name)
+    except Exception as e:
+        raise ValueError(f"Table '{table_name}' not found: {e}")
+
+    current_snap = table.current_snapshot()
+    if current_snap is None:
+        import pandas as pd
+        return {
+            "table": table_name,
+            "pipeline": pipeline_name,
+            "dataframe": pd.DataFrame(),
+            "row_count": 0,
+            "from_snapshot": None,
+            "to_snapshot": None,
+            "is_full": True,
+            "message": f"No snapshots in '{table_name}' — nothing to process",
+        }
+
+    current_id = current_snap.snapshot_id
+    watermark = get_watermark(pipeline_name, table_name, store_path=store_path)
+    last_snapshot_id = watermark["snapshot_id"]
+
+    if last_snapshot_id is not None and last_snapshot_id == current_id:
+        import pandas as pd
+        return {
+            "table": table_name,
+            "pipeline": pipeline_name,
+            "dataframe": pd.DataFrame(),
+            "row_count": 0,
+            "from_snapshot": last_snapshot_id,
+            "to_snapshot": current_id,
+            "is_full": False,
+            "message": f"No new data in '{table_name}' since snapshot {last_snapshot_id}",
+        }
+
+    if last_snapshot_id is None:
+        # No watermark — full scan
+        arrow = table.scan().to_arrow()
+        df = arrow.to_pandas()
+        return {
+            "table": table_name,
+            "pipeline": pipeline_name,
+            "dataframe": df,
+            "row_count": len(df),
+            "from_snapshot": None,
+            "to_snapshot": current_id,
+            "is_full": True,
+            "message": f"Full scan of '{table_name}': {len(df)} rows (no prior watermark)",
+        }
+
+    # Incremental: get data added between watermark snapshot and current
+    # Read both snapshots and diff
+    old_arrow = scan_as_of(catalog, table_name, str(last_snapshot_id))
+    new_arrow = table.scan().to_arrow()
+
+    import duckdb
+    conn = duckdb.connect(":memory:")
+    conn.register("old_data", old_arrow)
+    conn.register("new_data", new_arrow)
+
+    # Find rows in new that are not in old (added rows)
+    columns = [f.name for f in table.schema().fields]
+    col_list = ", ".join(columns)
+
+    result = conn.execute(
+        f"SELECT {col_list} FROM new_data EXCEPT SELECT {col_list} FROM old_data"
+    ).fetchdf()
+    conn.close()
+
+    return {
+        "table": table_name,
+        "pipeline": pipeline_name,
+        "dataframe": result,
+        "row_count": len(result),
+        "from_snapshot": last_snapshot_id,
+        "to_snapshot": current_id,
+        "is_full": False,
+        "message": f"Incremental data for '{table_name}': {len(result)} new rows (snapshot {last_snapshot_id} → {current_id})",
+    }
+
+
+def run_pipeline_incremental(
+    name: str,
+    catalog,
+    engine,
+    store_path: Optional[Path] = None,
+    watermark_path: Optional[Path] = None,
+) -> dict:
+    """Run a pipeline in incremental mode.
+
+    For each step with a source table, reads only new data since the last watermark.
+    Updates watermarks after successful completion.
+    """
+    from .pipelines import get_pipeline
+    from .catalog import insert_rows, create_table
+
+    pipeline = get_pipeline(name, store_path=store_path)
+    if pipeline is None:
+        raise ValueError(f"Pipeline '{name}' not found")
+
+    steps = pipeline["steps"]
+    step_results = []
+    source_snapshots = {}  # Track current snapshot per source table
+
+    for i, step in enumerate(steps):
+        source = step.get("source_table")
+        target = step.get("target_table")
+
+        if source:
+            source_tbl = _normalize(source)
+
+            # Get incremental data
+            inc = get_incremental_data(catalog, source_tbl, name, store_path=watermark_path)
+
+            if inc["row_count"] == 0:
+                step_results.append({
+                    "step": i + 1,
+                    "source": source_tbl,
+                    "target": target,
+                    "status": "skipped",
+                    "rows": 0,
+                    "message": "No new data to process",
+                })
+                continue
+
+            # Track the snapshot for watermark update
+            source_snapshots[source_tbl] = inc["to_snapshot"]
+
+            # Register incremental data and run the SQL against it
+            import duckdb
+            conn = duckdb.connect(":memory:")
+            short_name = source.split(".")[-1] if "." in source else source
+            conn.register(short_name, inc["dataframe"])
+
+            sql = step.get("sql", f"SELECT * FROM {short_name}")
+            result_df = conn.execute(sql).fetchdf()
+            conn.close()
+
+            if target:
+                target_tbl = _normalize(target)
+                rows = result_df.to_dict(orient="records")
+                if rows:
+                    try:
+                        catalog.load_table(target_tbl)
+                    except Exception:
+                        # Create target if it doesn't exist
+                        columns = {col: "string" for col in result_df.columns}
+                        create_table(catalog, target, columns=columns)
+                    insert_rows(catalog, target_tbl, rows)
+
+            step_results.append({
+                "step": i + 1,
+                "source": source_tbl,
+                "target": target,
+                "status": "success",
+                "rows": len(result_df),
+                "is_full": inc["is_full"],
+                "message": f"Processed {len(result_df)} rows",
+            })
+        else:
+            # Non-source steps run as-is
+            try:
+                sql = step.get("sql", "")
+                if sql:
+                    engine.execute(sql)
+                step_results.append({
+                    "step": i + 1,
+                    "status": "success",
+                    "message": "Executed SQL",
+                })
+            except Exception as e:
+                step_results.append({
+                    "step": i + 1,
+                    "status": "failed",
+                    "message": str(e),
+                })
+                return {
+                    "pipeline": name,
+                    "status": "failed",
+                    "steps": step_results,
+                    "message": f"Pipeline '{name}' failed at step {i + 1}: {e}",
+                }
+
+    # Update watermarks for all processed sources
+    for tbl, snap_id in source_snapshots.items():
+        if snap_id is not None:
+            rows_total = sum(
+                s.get("rows", 0) for s in step_results
+                if s.get("source") == tbl and s.get("status") == "success"
+            )
+            set_watermark(name, tbl, snap_id, rows_processed=rows_total, store_path=watermark_path)
+
+    total_rows = sum(s.get("rows", 0) for s in step_results)
+    return {
+        "pipeline": name,
+        "status": "success",
+        "steps": step_results,
+        "total_rows": total_rows,
+        "watermarks_updated": len(source_snapshots),
+        "message": f"Pipeline '{name}' completed: {total_rows} rows processed across {len(step_results)} step(s)",
+    }

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -1,0 +1,228 @@
+"""Tests for incremental processing (watermark-based pipeline runs)."""
+
+import json
+import pytest
+
+from lakehouse.incremental import (
+    set_watermark,
+    get_watermark,
+    list_watermarks,
+    reset_watermark,
+    get_incremental_data,
+    run_pipeline_incremental,
+)
+from lakehouse.pipelines import create_pipeline
+from lakehouse.catalog import create_table, insert_rows
+from lakehouse.query import QueryEngine
+
+
+@pytest.fixture
+def wm_path(tmp_path):
+    """Return a temporary watermark store path."""
+    return tmp_path / "watermarks.json"
+
+
+@pytest.fixture
+def pipe_path(tmp_path):
+    """Return a temporary pipeline store path."""
+    return tmp_path / "pipelines.json"
+
+
+@pytest.fixture
+def inc_table(test_catalog):
+    """Create a table with initial data (3 rows)."""
+    create_table(test_catalog, "events", columns={"id": "long", "event": "string"})
+    insert_rows(test_catalog, "default.events", [
+        {"id": 1, "event": "click"},
+        {"id": 2, "event": "view"},
+        {"id": 3, "event": "purchase"},
+    ])
+    return test_catalog
+
+
+# --- set/get watermark ---
+
+
+class TestWatermark:
+    def test_set_and_get(self, wm_path):
+        """Set and retrieve a watermark."""
+        set_watermark("etl", "events", 12345, rows_processed=100, store_path=wm_path)
+        result = get_watermark("etl", "events", store_path=wm_path)
+        assert result["snapshot_id"] == 12345
+        assert result["rows_processed"] == 100
+
+    def test_get_nonexistent(self, wm_path):
+        """Get a nonexistent watermark returns None snapshot."""
+        result = get_watermark("nope", "nope", store_path=wm_path)
+        assert result["snapshot_id"] is None
+
+    def test_overwrite(self, wm_path):
+        """Setting a watermark again overwrites."""
+        set_watermark("etl", "events", 111, store_path=wm_path)
+        set_watermark("etl", "events", 222, store_path=wm_path)
+        result = get_watermark("etl", "events", store_path=wm_path)
+        assert result["snapshot_id"] == 222
+
+
+# --- list_watermarks ---
+
+
+class TestListWatermarks:
+    def test_list_all(self, wm_path):
+        """List all watermarks."""
+        set_watermark("a", "t1", 1, store_path=wm_path)
+        set_watermark("b", "t2", 2, store_path=wm_path)
+        results = list_watermarks(store_path=wm_path)
+        assert len(results) == 2
+
+    def test_list_by_pipeline(self, wm_path):
+        """List watermarks filtered by pipeline."""
+        set_watermark("a", "t1", 1, store_path=wm_path)
+        set_watermark("a", "t2", 2, store_path=wm_path)
+        set_watermark("b", "t3", 3, store_path=wm_path)
+        results = list_watermarks(pipeline_name="a", store_path=wm_path)
+        assert len(results) == 2
+
+    def test_list_empty(self, wm_path):
+        """Empty store returns empty list."""
+        assert list_watermarks(store_path=wm_path) == []
+
+
+# --- reset_watermark ---
+
+
+class TestResetWatermark:
+    def test_reset_table(self, wm_path):
+        """Reset watermark for a specific table."""
+        set_watermark("etl", "events", 123, store_path=wm_path)
+        reset_watermark("etl", table_name="events", store_path=wm_path)
+        result = get_watermark("etl", "events", store_path=wm_path)
+        assert result["snapshot_id"] is None
+
+    def test_reset_all(self, wm_path):
+        """Reset all watermarks for a pipeline."""
+        set_watermark("etl", "t1", 1, store_path=wm_path)
+        set_watermark("etl", "t2", 2, store_path=wm_path)
+        reset_watermark("etl", store_path=wm_path)
+        assert list_watermarks(pipeline_name="etl", store_path=wm_path) == []
+
+    def test_reset_nonexistent(self, wm_path):
+        """Resetting nonexistent pipeline is a no-op."""
+        result = reset_watermark("nope", store_path=wm_path)
+        assert "no watermarks" in result["message"].lower()
+
+
+# --- get_incremental_data ---
+
+
+class TestGetIncrementalData:
+    def test_no_watermark_returns_all(self, inc_table, wm_path):
+        """No watermark returns all rows (full scan)."""
+        result = get_incremental_data(inc_table, "events", "etl", store_path=wm_path)
+        assert result["row_count"] == 3
+        assert result["is_full"] is True
+
+    def test_incremental_returns_new_rows(self, inc_table, wm_path):
+        """With watermark, returns only new rows."""
+        # Get current snapshot and set as watermark
+        table = inc_table.load_table("default.events")
+        snap_id = table.current_snapshot().snapshot_id
+        set_watermark("etl", "events", snap_id, store_path=wm_path)
+
+        # Add new rows
+        insert_rows(inc_table, "default.events", [
+            {"id": 4, "event": "signup"},
+            {"id": 5, "event": "logout"},
+        ])
+
+        result = get_incremental_data(inc_table, "events", "etl", store_path=wm_path)
+        assert result["row_count"] == 2
+        assert result["is_full"] is False
+
+    def test_no_new_data(self, inc_table, wm_path):
+        """Same snapshot returns 0 rows."""
+        table = inc_table.load_table("default.events")
+        snap_id = table.current_snapshot().snapshot_id
+        set_watermark("etl", "events", snap_id, store_path=wm_path)
+
+        result = get_incremental_data(inc_table, "events", "etl", store_path=wm_path)
+        assert result["row_count"] == 0
+
+
+# --- run_pipeline_incremental ---
+
+
+class TestRunPipelineIncremental:
+    def test_full_first_run(self, inc_table, wm_path, pipe_path):
+        """First run processes all data."""
+        create_pipeline(
+            "etl",
+            steps=[{"source_table": "events", "target_table": "events_copy", "sql": "SELECT * FROM events"}],
+            store_path=pipe_path,
+        )
+        engine = QueryEngine(catalog=inc_table)
+        result = run_pipeline_incremental("etl", inc_table, engine, store_path=pipe_path, watermark_path=wm_path)
+        assert result["status"] == "success"
+        assert result["total_rows"] == 3
+        # Watermark should be updated
+        wm = get_watermark("etl", "events", store_path=wm_path)
+        assert wm["snapshot_id"] is not None
+
+    def test_incremental_second_run(self, inc_table, wm_path, pipe_path):
+        """Second run processes only new data."""
+        create_pipeline(
+            "etl",
+            steps=[{"source_table": "events", "target_table": "events_copy", "sql": "SELECT * FROM events"}],
+            store_path=pipe_path,
+        )
+        engine = QueryEngine(catalog=inc_table)
+
+        # First run
+        run_pipeline_incremental("etl", inc_table, engine, store_path=pipe_path, watermark_path=wm_path)
+
+        # Add new data
+        insert_rows(inc_table, "default.events", [{"id": 10, "event": "new_event"}])
+
+        # Second run should only process new data
+        result = run_pipeline_incremental("etl", inc_table, engine, store_path=pipe_path, watermark_path=wm_path)
+        assert result["status"] == "success"
+        assert result["total_rows"] == 1
+
+    def test_skip_when_no_new_data(self, inc_table, wm_path, pipe_path):
+        """Skip steps when no new data."""
+        create_pipeline(
+            "etl",
+            steps=[{"source_table": "events", "target_table": "events_copy", "sql": "SELECT * FROM events"}],
+            store_path=pipe_path,
+        )
+        engine = QueryEngine(catalog=inc_table)
+
+        # First run
+        run_pipeline_incremental("etl", inc_table, engine, store_path=pipe_path, watermark_path=wm_path)
+
+        # Second run without new data
+        result = run_pipeline_incremental("etl", inc_table, engine, store_path=pipe_path, watermark_path=wm_path)
+        assert result["steps"][0]["status"] == "skipped"
+        assert result["total_rows"] == 0
+
+    def test_nonexistent_pipeline_raises(self, inc_table, wm_path, pipe_path):
+        """Nonexistent pipeline raises ValueError."""
+        engine = QueryEngine(catalog=inc_table)
+        with pytest.raises(ValueError, match="not found"):
+            run_pipeline_incremental("nope", inc_table, engine, store_path=pipe_path, watermark_path=wm_path)
+
+
+# --- Storage format ---
+
+
+class TestStorageFormat:
+    def test_json_structure(self, wm_path):
+        """Store is valid JSON with expected structure."""
+        set_watermark("etl", "events", 12345, rows_processed=100, store_path=wm_path)
+        data = json.loads(wm_path.read_text())
+        assert "etl" in data
+        assert "default.events" in data["etl"]
+        entry = data["etl"]["default.events"]
+        assert entry["snapshot_id"] == 12345
+        assert "processed_at" in entry
+        assert entry["rows_processed"] == 100


### PR DESCRIPTION
## Summary
- Add `incremental.py` with 6 functions: `set_watermark`, `get_watermark`, `list_watermarks`, `reset_watermark`, `get_incremental_data`, `run_pipeline_incremental`
- Watermark-based incremental pipeline runs that only process new data since last snapshot
- 17 tests covering watermark CRUD, incremental data extraction, pipeline runs (full + incremental + skip)
- CLI commands: `watermark set/show/list/reset`
- MCP tools: `get_watermark`, `list_watermarks`, `reset_watermark`, `run_pipeline_incremental`

## Test plan
- [x] 17/17 incremental tests pass
- [x] Full suite: 800 passed, 2 failed (pre-existing upstream PyIceberg flaky issue)

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)