### PR TITLE
Implement change data capture (#95)

### DIFF
--- a/src/lakehouse/cdc.py
+++ b/src/lakehouse/cdc.py
@@ -1,0 +1,388 @@
+"""Change data capture — row-level change tracking between snapshots."""
+
+import csv
+import datetime
+import io
+import json
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_CDC_PATH = Path.home() / ".lakehouse" / "cdc.json"
+
+
+def _normalize(table_name: str) -> str:
+    if "." not in table_name:
+        return f"default.{table_name}"
+    return table_name
+
+
+def get_changes(
+    catalog,
+    table_name: str,
+    from_snapshot: Optional[str] = None,
+    to_snapshot: Optional[str] = None,
+    key_columns: Optional[list[str]] = None,
+) -> dict:
+    """Compute row-level changes between two snapshots.
+
+    Categorizes changes as INSERT, UPDATE, or DELETE.
+    Updates are detected when key columns match but other columns differ.
+    """
+    import duckdb
+    from .catalog import scan_as_of, get_snapshots, _resolve_snapshot_id
+
+    table_name = _normalize(table_name)
+    table = catalog.load_table(table_name)
+
+    # Resolve snapshots
+    snapshots = get_snapshots(catalog, table_name)
+    if not snapshots:
+        return {
+            "table": table_name,
+            "changes": [],
+            "summary": {"inserts": 0, "updates": 0, "deletes": 0},
+            "from_snapshot": None,
+            "to_snapshot": None,
+            "message": "No snapshots available",
+        }
+
+    if from_snapshot is not None:
+        from_arrow = scan_as_of(catalog, table_name, from_snapshot)
+        from_id = _resolve_snapshot_id(table, from_snapshot)
+    else:
+        # Use the second-to-last snapshot (or empty if only one)
+        if len(snapshots) < 2:
+            from_arrow = None
+            from_id = None
+        else:
+            from_id = snapshots[-2]["snapshot_id"]
+            from_arrow = scan_as_of(catalog, table_name, str(from_id))
+
+    if to_snapshot is not None:
+        to_arrow = scan_as_of(catalog, table_name, to_snapshot)
+        to_id = _resolve_snapshot_id(table, to_snapshot)
+    else:
+        to_arrow = table.scan().to_arrow()
+        current = table.current_snapshot()
+        to_id = current.snapshot_id if current else None
+
+    # Same snapshot — no changes
+    if from_id == to_id:
+        return {
+            "table": table_name,
+            "changes": [],
+            "summary": {"inserts": 0, "updates": 0, "deletes": 0},
+            "from_snapshot": from_id,
+            "to_snapshot": to_id,
+            "message": "No changes (same snapshot)",
+        }
+
+    columns = [field.name for field in to_arrow.schema]
+    col_list = ", ".join(f'"{c}"' for c in columns)
+
+    conn = duckdb.connect()
+
+    if from_arrow is None or from_arrow.num_rows == 0:
+        # All rows in to_snapshot are inserts
+        conn.register("to_tbl", to_arrow)
+        rows = conn.execute(f"SELECT {col_list} FROM to_tbl").fetchall()
+        conn.close()
+        changes = [
+            {"type": "INSERT", "row": dict(zip(columns, row))}
+            for row in rows
+        ]
+        return {
+            "table": table_name,
+            "changes": changes,
+            "summary": {"inserts": len(changes), "updates": 0, "deletes": 0},
+            "from_snapshot": from_id,
+            "to_snapshot": to_id,
+            "message": f"{len(changes)} inserts",
+        }
+
+    conn.register("from_tbl", from_arrow)
+    conn.register("to_tbl", to_arrow)
+
+    # Rows in to but not in from = potentially inserts or updates
+    added = conn.execute(
+        f"SELECT {col_list} FROM to_tbl EXCEPT SELECT {col_list} FROM from_tbl"
+    ).fetchall()
+    added_rows = [dict(zip(columns, row)) for row in added]
+
+    # Rows in from but not in to = potentially deletes or updates
+    removed = conn.execute(
+        f"SELECT {col_list} FROM from_tbl EXCEPT SELECT {col_list} FROM to_tbl"
+    ).fetchall()
+    removed_rows = [dict(zip(columns, row)) for row in removed]
+
+    conn.close()
+
+    # Detect updates using key columns
+    keys = key_columns or ([columns[0]] if columns else [])
+    changes = _classify_changes(added_rows, removed_rows, keys, columns)
+
+    inserts = sum(1 for c in changes if c["type"] == "INSERT")
+    updates = sum(1 for c in changes if c["type"] == "UPDATE")
+    deletes = sum(1 for c in changes if c["type"] == "DELETE")
+
+    parts = []
+    if inserts:
+        parts.append(f"{inserts} inserts")
+    if updates:
+        parts.append(f"{updates} updates")
+    if deletes:
+        parts.append(f"{deletes} deletes")
+
+    return {
+        "table": table_name,
+        "changes": changes,
+        "summary": {"inserts": inserts, "updates": updates, "deletes": deletes},
+        "from_snapshot": from_id,
+        "to_snapshot": to_id,
+        "message": ", ".join(parts) if parts else "No changes",
+    }
+
+
+def _classify_changes(
+    added_rows: list[dict],
+    removed_rows: list[dict],
+    keys: list[str],
+    columns: list[str],
+) -> list[dict]:
+    """Classify raw added/removed rows into INSERT, UPDATE, DELETE."""
+    changes = []
+
+    # Index removed rows by key for fast lookup
+    removed_by_key = {}
+    for row in removed_rows:
+        key = tuple(row.get(k) for k in keys)
+        removed_by_key[key] = row
+
+    matched_keys = set()
+
+    for row in added_rows:
+        key = tuple(row.get(k) for k in keys)
+        if key in removed_by_key:
+            # Key exists in both — this is an UPDATE
+            old_row = removed_by_key[key]
+            changed_cols = [c for c in columns if c not in keys and row.get(c) != old_row.get(c)]
+            changes.append({
+                "type": "UPDATE",
+                "key": dict(zip(keys, key)),
+                "before": old_row,
+                "after": row,
+                "changed_columns": changed_cols,
+            })
+            matched_keys.add(key)
+        else:
+            # New key — this is an INSERT
+            changes.append({"type": "INSERT", "row": row})
+
+    # Remaining removed rows are DELETEs
+    for row in removed_rows:
+        key = tuple(row.get(k) for k in keys)
+        if key not in matched_keys:
+            changes.append({"type": "DELETE", "row": row})
+
+    return changes
+
+
+def get_change_log(
+    catalog,
+    table_name: str,
+    limit: int = 100,
+    key_columns: Optional[list[str]] = None,
+) -> list[dict]:
+    """Get a chronological log of changes across all snapshots."""
+    from .catalog import get_snapshots
+
+    table_name = _normalize(table_name)
+    snapshots = get_snapshots(catalog, table_name)
+
+    if len(snapshots) < 2:
+        return []
+
+    log = []
+    pairs = list(zip(snapshots[:-1], snapshots[1:]))
+    # Most recent first
+    for old_snap, new_snap in reversed(pairs[-limit:]):
+        try:
+            result = get_changes(
+                catalog, table_name,
+                from_snapshot=str(old_snap["snapshot_id"]),
+                to_snapshot=str(new_snap["snapshot_id"]),
+                key_columns=key_columns,
+            )
+            log.append({
+                "from_snapshot": old_snap["snapshot_id"],
+                "to_snapshot": new_snap["snapshot_id"],
+                "timestamp": new_snap["timestamp"],
+                "operation": new_snap.get("operation", "unknown"),
+                "summary": result["summary"],
+                "change_count": sum(result["summary"].values()),
+            })
+        except Exception:
+            continue
+
+    return log
+
+
+def get_change_summary(
+    catalog,
+    table_name: str,
+    from_snapshot: Optional[str] = None,
+    to_snapshot: Optional[str] = None,
+    key_columns: Optional[list[str]] = None,
+) -> dict:
+    """Get summary statistics for changes between two snapshots."""
+    table_name = _normalize(table_name)
+    result = get_changes(
+        catalog, table_name,
+        from_snapshot=from_snapshot,
+        to_snapshot=to_snapshot,
+        key_columns=key_columns,
+    )
+
+    # Compute affected columns
+    affected_columns = set()
+    for change in result["changes"]:
+        if change["type"] == "UPDATE":
+            affected_columns.update(change.get("changed_columns", []))
+        elif change["type"] == "INSERT":
+            affected_columns.update(change["row"].keys())
+        elif change["type"] == "DELETE":
+            affected_columns.update(change["row"].keys())
+
+    total = sum(result["summary"].values())
+
+    return {
+        "table": table_name,
+        "from_snapshot": result["from_snapshot"],
+        "to_snapshot": result["to_snapshot"],
+        "inserts": result["summary"]["inserts"],
+        "updates": result["summary"]["updates"],
+        "deletes": result["summary"]["deletes"],
+        "total_changes": total,
+        "affected_columns": sorted(affected_columns),
+        "message": f"Change summary: {result['message']}",
+    }
+
+
+def export_changes(
+    catalog,
+    table_name: str,
+    from_snapshot: str,
+    to_snapshot: str,
+    format: str = "json",
+    key_columns: Optional[list[str]] = None,
+) -> str:
+    """Export CDC data to JSON or CSV string."""
+    table_name = _normalize(table_name)
+    result = get_changes(
+        catalog, table_name,
+        from_snapshot=from_snapshot,
+        to_snapshot=to_snapshot,
+        key_columns=key_columns,
+    )
+
+    if format == "json":
+        export = {
+            "table": table_name,
+            "from_snapshot": result["from_snapshot"],
+            "to_snapshot": result["to_snapshot"],
+            "exported_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "summary": result["summary"],
+            "changes": result["changes"],
+        }
+        return json.dumps(export, indent=2, default=str)
+
+    elif format == "csv":
+        output = io.StringIO()
+        writer = csv.writer(output)
+
+        # Collect all possible columns
+        all_cols = set()
+        for change in result["changes"]:
+            if change["type"] in ("INSERT", "DELETE"):
+                all_cols.update(change["row"].keys())
+            elif change["type"] == "UPDATE":
+                all_cols.update(change["after"].keys())
+        all_cols = sorted(all_cols)
+
+        writer.writerow(["change_type"] + all_cols)
+        for change in result["changes"]:
+            if change["type"] == "INSERT":
+                writer.writerow(["INSERT"] + [change["row"].get(c, "") for c in all_cols])
+            elif change["type"] == "DELETE":
+                writer.writerow(["DELETE"] + [change["row"].get(c, "") for c in all_cols])
+            elif change["type"] == "UPDATE":
+                writer.writerow(["UPDATE_BEFORE"] + [change["before"].get(c, "") for c in all_cols])
+                writer.writerow(["UPDATE_AFTER"] + [change["after"].get(c, "") for c in all_cols])
+
+        return output.getvalue()
+
+    else:
+        raise ValueError(f"Unsupported format: {format}. Use 'json' or 'csv'.")
+
+
+def replay_changes(
+    catalog,
+    changes: list[dict],
+    target_table: str,
+) -> dict:
+    """Apply captured changes to a target table."""
+    from .catalog import insert_rows, update_rows, delete_rows
+
+    target_table = _normalize(target_table)
+    applied = {"inserts": 0, "updates": 0, "deletes": 0, "errors": []}
+
+    for change in changes:
+        try:
+            if change["type"] == "INSERT":
+                insert_rows(catalog, target_table, [change["row"]])
+                applied["inserts"] += 1
+            elif change["type"] == "DELETE":
+                row = change["row"]
+                # Build filter from all columns
+                filters = []
+                for k, v in row.items():
+                    if v is None:
+                        filters.append(f'"{k}" IS NULL')
+                    elif isinstance(v, str):
+                        escaped = v.replace("'", "''")
+                        filters.append(f'"{k}" = \'{escaped}\'')
+                    else:
+                        filters.append(f'"{k}" = {v}')
+                filter_expr = " AND ".join(filters)
+                delete_rows(catalog, target_table, filter_expr)
+                applied["deletes"] += 1
+            elif change["type"] == "UPDATE":
+                key = change.get("key", {})
+                after = change.get("after", {})
+                if key:
+                    filters = []
+                    for k, v in key.items():
+                        if v is None:
+                            filters.append(f'"{k}" IS NULL')
+                        elif isinstance(v, str):
+                            escaped = v.replace("'", "''")
+                            filters.append(f'"{k}" = \'{escaped}\'')
+                        else:
+                            filters.append(f'"{k}" = {v}')
+                    filter_expr = " AND ".join(filters)
+                    # Update to after values (exclude key columns)
+                    updates = {c: v for c, v in after.items() if c not in key}
+                    if updates:
+                        update_rows(catalog, target_table, filter_expr, updates)
+                        applied["updates"] += 1
+        except Exception as e:
+            applied["errors"].append(f"{change['type']}: {str(e)}")
+
+    total = applied["inserts"] + applied["updates"] + applied["deletes"]
+    return {
+        "target_table": target_table,
+        "applied": applied,
+        "total_applied": total,
+        "errors": len(applied["errors"]),
+        "message": f"Replayed {total} changes to '{target_table}' ({len(applied['errors'])} errors)",
+    }

--- a/tests/test_cdc.py
+++ b/tests/test_cdc.py
@@ -1,0 +1,257 @@
+"""Tests for change data capture."""
+
+import json
+import pytest
+
+from lakehouse.cdc import (
+    get_changes,
+    get_change_log,
+    get_change_summary,
+    export_changes,
+    replay_changes,
+)
+from lakehouse.catalog import (
+    create_table,
+    insert_rows,
+    update_rows,
+    delete_rows,
+    get_snapshots,
+)
+
+
+@pytest.fixture
+def cdc_table(test_catalog):
+    """Create a table with initial data for CDC testing."""
+    create_table(test_catalog, "cdc_test", columns={"id": "long", "name": "string", "value": "double"})
+    insert_rows(test_catalog, "default.cdc_test", [
+        {"id": 1, "name": "alice", "value": 10.0},
+        {"id": 2, "name": "bob", "value": 20.0},
+        {"id": 3, "name": "charlie", "value": 30.0},
+    ])
+    return test_catalog
+
+
+@pytest.fixture
+def cdc_snapshots(cdc_table):
+    """Return catalog and snapshot IDs after initial insert."""
+    snaps = get_snapshots(cdc_table, "cdc_test")
+    return cdc_table, snaps
+
+
+# --- Insert detection ---
+
+
+class TestInsertDetection:
+    def test_detect_inserts(self, cdc_snapshots):
+        catalog, snaps = cdc_snapshots
+        before_snap = str(snaps[-1]["snapshot_id"])
+
+        insert_rows(catalog, "default.cdc_test", [
+            {"id": 4, "name": "diana", "value": 40.0},
+        ])
+        snaps_after = get_snapshots(catalog, "cdc_test")
+        after_snap = str(snaps_after[-1]["snapshot_id"])
+
+        result = get_changes(catalog, "cdc_test", from_snapshot=before_snap, to_snapshot=after_snap, key_columns=["id"])
+        assert result["summary"]["inserts"] == 1
+        assert result["summary"]["deletes"] == 0
+        assert result["summary"]["updates"] == 0
+        inserted = [c for c in result["changes"] if c["type"] == "INSERT"]
+        assert inserted[0]["row"]["name"] == "diana"
+
+    def test_all_inserts_from_empty(self, test_catalog):
+        """First snapshot — all rows are inserts."""
+        create_table(test_catalog, "fresh", columns={"id": "long", "val": "string"})
+        insert_rows(test_catalog, "default.fresh", [{"id": 1, "val": "a"}, {"id": 2, "val": "b"}])
+
+        result = get_changes(test_catalog, "fresh", key_columns=["id"])
+        # With only one snapshot, from_snapshot is None so all are inserts
+        assert result["summary"]["inserts"] == 2
+
+
+# --- Delete detection ---
+
+
+class TestDeleteDetection:
+    def test_detect_deletes(self, cdc_snapshots):
+        catalog, snaps = cdc_snapshots
+        before_snap = str(snaps[-1]["snapshot_id"])
+
+        delete_rows(catalog, "default.cdc_test", '"id" = 2')
+        snaps_after = get_snapshots(catalog, "cdc_test")
+        after_snap = str(snaps_after[-1]["snapshot_id"])
+
+        result = get_changes(catalog, "cdc_test", from_snapshot=before_snap, to_snapshot=after_snap, key_columns=["id"])
+        assert result["summary"]["deletes"] == 1
+        deleted = [c for c in result["changes"] if c["type"] == "DELETE"]
+        assert deleted[0]["row"]["id"] == 2
+
+
+# --- Update detection ---
+
+
+class TestUpdateDetection:
+    def test_detect_updates(self, cdc_snapshots):
+        catalog, snaps = cdc_snapshots
+        before_snap = str(snaps[-1]["snapshot_id"])
+
+        update_rows(catalog, "default.cdc_test", '"id" = 1', {"name": "alice_updated"})
+        snaps_after = get_snapshots(catalog, "cdc_test")
+        after_snap = str(snaps_after[-1]["snapshot_id"])
+
+        result = get_changes(catalog, "cdc_test", from_snapshot=before_snap, to_snapshot=after_snap, key_columns=["id"])
+        assert result["summary"]["updates"] == 1
+        updated = [c for c in result["changes"] if c["type"] == "UPDATE"]
+        assert updated[0]["before"]["name"] == "alice"
+        assert updated[0]["after"]["name"] == "alice_updated"
+        assert "name" in updated[0]["changed_columns"]
+
+    def test_detect_mixed_operations(self, cdc_snapshots):
+        """Insert + update + delete in one diff."""
+        catalog, snaps = cdc_snapshots
+        before_snap = str(snaps[-1]["snapshot_id"])
+
+        # Insert new row
+        insert_rows(catalog, "default.cdc_test", [{"id": 4, "name": "diana", "value": 40.0}])
+        # Update existing
+        update_rows(catalog, "default.cdc_test", '"id" = 1', {"value": 99.0})
+        # Delete existing
+        delete_rows(catalog, "default.cdc_test", '"id" = 3')
+
+        snaps_after = get_snapshots(catalog, "cdc_test")
+        after_snap = str(snaps_after[-1]["snapshot_id"])
+
+        result = get_changes(catalog, "cdc_test", from_snapshot=before_snap, to_snapshot=after_snap, key_columns=["id"])
+        assert result["summary"]["inserts"] >= 1
+        assert result["summary"]["updates"] >= 1
+        assert result["summary"]["deletes"] >= 1
+
+
+# --- Same snapshot / no changes ---
+
+
+class TestEdgeCases:
+    def test_same_snapshot_no_changes(self, cdc_snapshots):
+        catalog, snaps = cdc_snapshots
+        snap_id = str(snaps[-1]["snapshot_id"])
+        result = get_changes(catalog, "cdc_test", from_snapshot=snap_id, to_snapshot=snap_id)
+        assert result["summary"]["inserts"] == 0
+        assert result["summary"]["updates"] == 0
+        assert result["summary"]["deletes"] == 0
+
+    def test_default_snapshots(self, cdc_snapshots):
+        """Without explicit snapshots, uses last two."""
+        catalog, snaps = cdc_snapshots
+        # Add a new snapshot
+        insert_rows(catalog, "default.cdc_test", [{"id": 5, "name": "eve", "value": 50.0}])
+        result = get_changes(catalog, "cdc_test", key_columns=["id"])
+        assert result["summary"]["inserts"] >= 1
+
+
+# --- Change log ---
+
+
+class TestChangeLog:
+    def test_change_log(self, cdc_snapshots):
+        catalog, snaps = cdc_snapshots
+        # Make more changes to create multiple snapshots
+        insert_rows(catalog, "default.cdc_test", [{"id": 4, "name": "d", "value": 40.0}])
+        insert_rows(catalog, "default.cdc_test", [{"id": 5, "name": "e", "value": 50.0}])
+
+        log = get_change_log(catalog, "cdc_test", key_columns=["id"])
+        assert len(log) >= 2
+        for entry in log:
+            assert "from_snapshot" in entry
+            assert "to_snapshot" in entry
+            assert "timestamp" in entry
+            assert "summary" in entry
+            assert "change_count" in entry
+
+    def test_change_log_single_snapshot(self, test_catalog):
+        """Table with one snapshot has empty log."""
+        create_table(test_catalog, "solo", columns={"id": "long"})
+        insert_rows(test_catalog, "default.solo", [{"id": 1}])
+        log = get_change_log(test_catalog, "solo")
+        assert log == []
+
+
+# --- Change summary ---
+
+
+class TestChangeSummary:
+    def test_summary(self, cdc_snapshots):
+        catalog, snaps = cdc_snapshots
+        before_snap = str(snaps[-1]["snapshot_id"])
+
+        insert_rows(catalog, "default.cdc_test", [{"id": 4, "name": "diana", "value": 40.0}])
+        snaps_after = get_snapshots(catalog, "cdc_test")
+        after_snap = str(snaps_after[-1]["snapshot_id"])
+
+        result = get_change_summary(catalog, "cdc_test", from_snapshot=before_snap, to_snapshot=after_snap, key_columns=["id"])
+        assert result["inserts"] == 1
+        assert result["total_changes"] == 1
+        assert "affected_columns" in result
+        assert len(result["affected_columns"]) >= 1
+
+
+# --- Export ---
+
+
+class TestExport:
+    def test_export_json(self, cdc_snapshots):
+        catalog, snaps = cdc_snapshots
+        before_snap = str(snaps[-1]["snapshot_id"])
+
+        insert_rows(catalog, "default.cdc_test", [{"id": 4, "name": "diana", "value": 40.0}])
+        snaps_after = get_snapshots(catalog, "cdc_test")
+        after_snap = str(snaps_after[-1]["snapshot_id"])
+
+        output = export_changes(catalog, "cdc_test", before_snap, after_snap, format="json", key_columns=["id"])
+        data = json.loads(output)
+        assert data["table"] == "default.cdc_test"
+        assert data["summary"]["inserts"] == 1
+        assert len(data["changes"]) == 1
+
+    def test_export_csv(self, cdc_snapshots):
+        catalog, snaps = cdc_snapshots
+        before_snap = str(snaps[-1]["snapshot_id"])
+
+        insert_rows(catalog, "default.cdc_test", [{"id": 4, "name": "diana", "value": 40.0}])
+        snaps_after = get_snapshots(catalog, "cdc_test")
+        after_snap = str(snaps_after[-1]["snapshot_id"])
+
+        output = export_changes(catalog, "cdc_test", before_snap, after_snap, format="csv", key_columns=["id"])
+        assert "change_type" in output
+        assert "INSERT" in output
+
+    def test_export_invalid_format(self, cdc_snapshots):
+        catalog, snaps = cdc_snapshots
+        with pytest.raises(ValueError, match="Unsupported format"):
+            export_changes(catalog, "cdc_test", str(snaps[-1]["snapshot_id"]), str(snaps[-1]["snapshot_id"]), format="xml")
+
+
+# --- Replay ---
+
+
+class TestReplay:
+    def test_replay_inserts(self, cdc_snapshots):
+        catalog, snaps = cdc_snapshots
+        before_snap = str(snaps[-1]["snapshot_id"])
+
+        insert_rows(catalog, "default.cdc_test", [{"id": 4, "name": "diana", "value": 40.0}])
+        snaps_after = get_snapshots(catalog, "cdc_test")
+        after_snap = str(snaps_after[-1]["snapshot_id"])
+
+        changes_result = get_changes(catalog, "cdc_test", from_snapshot=before_snap, to_snapshot=after_snap, key_columns=["id"])
+
+        # Create target table
+        create_table(catalog, "cdc_target", columns={"id": "long", "name": "string", "value": "double"})
+        insert_rows(catalog, "default.cdc_target", [
+            {"id": 1, "name": "alice", "value": 10.0},
+            {"id": 2, "name": "bob", "value": 20.0},
+            {"id": 3, "name": "charlie", "value": 30.0},
+        ])
+
+        result = replay_changes(catalog, changes_result["changes"], "cdc_target")
+        assert result["total_applied"] == 1
+        assert result["applied"]["inserts"] == 1


### PR DESCRIPTION
## Summary
- Adds row-level change tracking between Iceberg snapshots with INSERT, UPDATE, and DELETE detection
- UPDATE detection via key-column matching (rows with same key but different values)
- 5 core functions: `get_changes`, `get_change_log`, `get_change_summary`, `export_changes`, `replay_changes`
- Export to JSON/CSV formats; replay changes to target tables for replication
- 14 tests, 4 CLI commands (`cdc` group), 4 MCP tools

Closes #95

## Test plan
- [x] 14 unit tests pass (insert/update/delete detection, mixed ops, export JSON/CSV, replay, edge cases)
- [x] Full suite: 853 passed, 2 failed (pre-existing upstream PyIceberg snapshot expiry bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)